### PR TITLE
ctrlk feature

### DIFF
--- a/extensions/void/src/CtrlKCodeLensProvider.ts
+++ b/extensions/void/src/CtrlKCodeLensProvider.ts
@@ -1,31 +1,66 @@
 import * as vscode from 'vscode';
+import { ApiConfig,sendLLMMessage } from './common/sendLLMMessage'; 
+import { ApprovalCodeLensProvider } from './ApprovalCodeLensProvider';
+import { SuggestedEdit } from './ApprovalCodeLensProvider';
 
-export class CtrlKCodeLensProvider implements vscode.CodeLensProvider {
+export class CtrlKCodeLensProvider {
+    private decoration: vscode.TextEditorDecorationType;
+    private apiConfig: ApiConfig | null = {
+        anthropic: { apikey: 'your-anthropic-api-key' },
+        openai: { apikey: 'your-openai-api-key' },
+        greptile: { apikey: 'your-greptile-api-key', githubPAT: 'your-github-pat', repoinfo: { remote: 'github', repository: 'voideditor/void', branch: 'main' }},
+        ollama: { endpoint: 'your-ollama-endpoint', model: 'your-model' },
+        whichApi: 'openai' // or 'anthropic', 'greptile', etc.
+    };
 
-	private codelensesOfDocument: { [documentUri: string]: vscode.CodeLens[] } = {};
+    // highlight
+    constructor() {
+        this.decoration = vscode.window.createTextEditorDecorationType({
+            backgroundColor: '#3c3c3c',
+            border: '1px solid #565656',
+            borderRadius: '3px'
+        });
+    }
 
-	// only called by vscode's internals
-	public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
-		const docUri = document.uri.toString()
-		return this.codelensesOfDocument[docUri];
-	}
+    public async showInlineInput(editor: vscode.TextEditor, range: vscode.Range) {
+        editor.setDecorations(this.decoration, [range]);
 
-	// only called by us
-	public addNewCodeLens(document: vscode.TextDocument, selection: vscode.Selection) {
+        const result = await vscode.window.showInputBox({
+            prompt: "Enter your prompt here",
+            placeHolder: "Enter your input here",
+            ignoreFocusOut: true   // Keep the input box open when focus is lost
+        });
+        if (result) {
+            const highlightedCode = editor.document.getText(range);
+            
+            const { abort } = sendLLMMessage({
+                // Send the user's prompt to llm.
+                messages: [{ role: 'user', content: result + highlightedCode }],
+                onText: (newText, fullText) => {
 
-		const docUri = document.uri.toString()
+                },
+                onFinalMessage: async (content) => {
+                    // Create a SuggestedEdit object 
+                    const suggestedEdit: SuggestedEdit = {
+                        startLine: range.start.line,
+                        endLine: range.end.line,
+                        originalStartLine: range.start.line,
+                        originalEndLine: range.end.line,
+                        originalContent: highlightedCode, // The original highlighted code
+                        newContent: content // The response from the LLM
+                    };
 
-		if (!this.codelensesOfDocument[docUri])
-			this.codelensesOfDocument[docUri] = []
+                    const editor = vscode.window.activeTextEditor;
+                    if (editor) {
+                        // Send to approvalProvider for accept/reject
+                        const approvalProvider = new ApprovalCodeLensProvider();
+                        await approvalProvider.addNewApprovals(editor, [suggestedEdit]);
+                    }
+                },
+                apiConfig: this.apiConfig
+            });
+        }
 
-		// if any other codelens intersects with the selection, don't do it (and have the user now focus that codelens)
-		for (let lens of this.codelensesOfDocument[docUri]) {
-			if (lens.range.intersection(selection))
-				return
-		}
-
-		this.codelensesOfDocument[docUri] = [
-			...this.codelensesOfDocument[docUri],
-			new vscode.CodeLens(new vscode.Range(selection.start.line, 0, selection.end.line, Infinity), { title: '', command: '' })];
-	}
+        editor.setDecorations(this.decoration, []);
+    }
 }

--- a/extensions/void/src/extension.ts
+++ b/extensions/void/src/extension.ts
@@ -25,7 +25,8 @@ const getApiConfig = () => {
 			}
 		},
 		ollama: {
-			// apikey: vscode.workspace.getConfiguration('void').get('ollamaSettings') ?? '',
+			endpoint: vscode.workspace.getConfiguration('void').get('ollamaSettings.endpoint') ?? '',
+			model: vscode.workspace.getConfiguration('void').get('ollamaSettings.model') ?? '',
 		},
 		whichApi: vscode.workspace.getConfiguration('void').get('whichApi') ?? ''
 	}
@@ -132,22 +133,17 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 	)
 
+	const inlineInputProvider = new CtrlKCodeLensProvider();
 
-
-
-	// Gets called when user presses ctrl + k (mounts ctrl+k-style codelens)
-	// TODO need to build this
-	// const ctrlKCodeLensProvider = new CtrlKCodeLensProvider();
-	// context.subscriptions.push(vscode.languages.registerCodeLensProvider('*', ctrlKCodeLensProvider));
-	// context.subscriptions.push(
-	// 	vscode.commands.registerCommand('void.ctrl+k', () => {
-	// 		const editor = vscode.window.activeTextEditor;
-	// 		if (!editor)
-	// 			return
-	// 		ctrlKCodeLensProvider.addNewCodeLens(editor.document, editor.selection);
-	// 		// vscode.commands.executeCommand('editor.action.showHover'); // apparently this refreshes the codelenses by having the internals call provideCodeLenses
-	// 	})
-	// )
-
+    context.subscriptions.push(vscode.commands.registerCommand('void.ctrl+k', async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (editor) {
+            const selection = editor.selection; // Get the current selection
+			if (selection.isEmpty) {
+				console.log('No text selected!');
+				return; // or show a message to the user
+			}
+			await inlineInputProvider.showInlineInput(editor, selection);
+        }
+    }));
 }
-


### PR DESCRIPTION
We probably don't need a codelens just for ctrlk, could reuse approvalcodelens. Also manually entered apiconfig for testing functionality. 