### PR TITLE
Link to settings from extension

### DIFF
--- a/extensions/void/package.json
+++ b/extensions/void/package.json
@@ -1,5 +1,6 @@
 {
   "name": "void",
+  "publisher": "void",
   "displayName": "Void",
   "description": "",
   "version": "0.0.1",
@@ -13,12 +14,18 @@
   "main": "./out/extension.js",
   "contributes": {
     "configuration": {
-      "title": "API Keys",
+      "title": "Void",
       "properties": {
         "void.whichApi": {
           "type": "string",
           "default": "anthropic",
-          "description": "Choose a model to use (anthropic | openai | greptile | ollama)"
+          "description": "Choose a model to use",
+          "enum": [
+            "anthropic",
+            "openai",
+            "greptile",
+            "ollama"
+          ]
         },
         "void.anthropicApiKey": {
           "type": "string",
@@ -63,6 +70,11 @@
       {
         "command": "void.discardDiff",
         "title": "Discard Diff"
+      },
+      {
+        "command": "void.openSettings",
+        "title": "Void settings",
+        "icon": "$(settings-gear)"
       }
     ],
     "viewsContainers": {
@@ -94,7 +106,16 @@
         "key": "ctrl+k",
         "mac": "cmd+k"
       }
-    ]
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "void.openSettings",
+          "when": "view == 'void.viewnumberone'",
+          "group": "navigation"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/extensions/void/src/extension.ts
+++ b/extensions/void/src/extension.ts
@@ -78,6 +78,9 @@ export function activate(context: vscode.ExtensionContext) {
 		approvalCodeLensProvider.discardDiff(params)
 	}));
 
+	context.subscriptions.push(vscode.commands.registerCommand('void.openSettings', async () => {
+		vscode.commands.executeCommand('workbench.action.openSettings', '@ext:void.void');
+	}));
 
 	// 5.
 	webviewProvider.webview.then(


### PR DESCRIPTION
- You can open Void settings directly from the sidebar.
- Which API is now a dropdown.

![image](https://github.com/user-attachments/assets/f58e9c7a-fff5-46ab-8ce5-7eda86ead11a)
