### PR TITLE
Update sendLLMMessage.ts

### DIFF
--- a/extensions/void/src/common/sendLLMMessage.ts
+++ b/extensions/void/src/common/sendLLMMessage.ts
@@ -119,7 +119,8 @@ const sendOpenAIMsg: SendLLMMessageFnTypeInternal = ({ messages, onText, onFinal
 		didAbort = true;
 	};
 
-	const openai = new OpenAI({ apiKey: apiConfig.openAI.apikey, dangerouslyAllowBrowser: true });
+	//const openai = new OpenAI({ apiKey: apiConfig.openAI.apikey, dangerouslyAllowBrowser: true });
+	const openai = apiConfig.whichApi === 'openAICompatible' ? new OpenAI({ baseURL: apiConfig.openAICompatible.endpoint, apiKey: apiConfig.openAICompatible.apikey, dangerouslyAllowBrowser: true }) : new OpenAI({ apiKey: apiConfig.openAI.apikey, dangerouslyAllowBrowser: true });
 
 	let options: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming
 	if (apiConfig.whichApi === 'openAI') {


### PR DESCRIPTION
In order to take the enpoint specified for the OpenAICompatible setting - the openai class needs to be instanciated with the baseURL setting from apiConfig