### PR TITLE
lodash : package added to extension

### DIFF
--- a/extensions/void/package-lock.json
+++ b/extensions/void/package-lock.json
@@ -41,6 +41,7 @@
         "eslint-plugin-react": "^7.35.1",
         "eslint-plugin-react-hooks": "^4.6.2",
         "globals": "^15.9.0",
+        "lodash": "^4.17.21",
         "marked": "^14.1.0",
         "ollama": "^0.5.9",
         "openai": "^4.68.4",
@@ -5040,6 +5041,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/extensions/void/package.json
+++ b/extensions/void/package.json
@@ -143,6 +143,7 @@
     "eslint-plugin-react": "^7.35.1",
     "eslint-plugin-react-hooks": "^4.6.2",
     "globals": "^15.9.0",
+    "lodash": "^4.17.21",
     "marked": "^14.1.0",
     "ollama": "^0.5.9",
     "openai": "^4.68.4",


### PR DESCRIPTION
After rebuilding the extension following recent changes, I had this problem : 

![Capture d’écran 2024-11-18 à 12 55 38](https://github.com/user-attachments/assets/7b73b127-8d63-4378-ac77-ad2180f08d5c)

So I checked into extensions/void/packages.json and saw that lodash wasn't here. 

As there is an error message if it is not here, I added the package to devDeps. 

Here is the extensions after : 

![Capture d’écran 2024-11-18 à 12 56 30](https://github.com/user-attachments/assets/b3b9ebbd-2976-4691-af8e-110779cf558b)

We are still waiting for #122 to be fixed, so it will allow us to edit the extension settings
 
