### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,16 @@ Alternatively, if you want to build Void from the terminal, instead of pressing 
 
 ## Bundling
 
-We don't usually recommend bundling. Instead, you should probably just build. If you're sure you want to bundle Void into an executable app, make sure you've built first, then run one of the following commands. This will create a folder named `VSCode-darwin-arm64` (or similar) in the repo's parent's directory. Be patient - compiling can take ~25 minutes.
+We don't usually recommend bundling. Instead, you should probably just build. If you're sure you want to bundle Void into an executable app, make sure you've built first, then run one of the following commands. This will create a folder named `VSCode-darwin-arm64` (or similar) in the repo's parent's directory(Refer the Folder structure below). Be patient - compiling can take ~25 minutes.
+
+```bash
+workspace/
+├── void/   # Your Void Fork
+├── VSCode-linux-x64/ # Build folder generated outside of void for Linux
+└── VSCode-darwin-arm64/ # Build folder generated outside of void for MacOs
+
+```
+
 
 ### Mac
 - `npm run gulp vscode-darwin-arm64` - most common (Apple Silicon)


### PR DESCRIPTION
Added details about Bundling output. Most of us open only the repo without workspace to save memory. It's easy to miss out on where the bundle is located. Added clarity!