### PR TITLE
Fix npm run watchreact initial build bug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ First, run `npm install -g node-gyp`. Then:
 To build Void, open `void/` inside VSCode. Then open your terminal and run:
 
 1. `npm install` to install all dependencies.
-2. `npm run watchreact` to build Void's browser dependencies like React.
+2. `npm run watchreact` to build Void's browser dependencies like React. (If this doesn't work, try `npm run buildreact`).
 3. Build Void.
 	 - Press <kbd>Cmd+Shift+B</kbd> (Mac).
    - Press <kbd>Ctrl+Shift+B</kbd> (Windows/Linux).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Welcome! 👋 This is the official guide on how to contribute to Void. We want to make it as easy as possible to contribute, so if you have any questions or comments, reach out via email or discord!
 
 
-If you'd like to get started developing Void, feel free to follow the steps below on building Void yourself and doing a PR. 
+If you'd like to get started developing Void, feel free to follow the steps below on building Void yourself and doing a PR.
 Void's code mostly lives in `src/vs/workbench/contrib/void/` and `src/vs/platform/void/`.
 
 There are a few ways to contribute:
@@ -47,7 +47,7 @@ First, run `npm install -g node-gyp`. Then:
 To build Void, open `void/` inside VSCode. Then open your terminal and run:
 
 1. `npm install` to install all dependencies.
-2. `npm run watchreact` to build Void's browser dependencies like React. (If this doesn't work, try `npm run buildreact`).
+2. `npm run watchreact` to build Void's browser dependencies like React.
 3. Build Void.
 	 - Press <kbd>Cmd+Shift+B</kbd> (Mac).
    - Press <kbd>Ctrl+Shift+B</kbd> (Windows/Linux).
@@ -111,7 +111,7 @@ workspace/
 ```
 
 ### Distributing
-Void's maintainers distribute Void on our website and in releases. If you'd like to see the scripts to convert `Mac .app -> .dmg`, `Windows folder -> .exe`, and `Linux folder -> appimage` for distribution, feel free to reach out. 
+Void's maintainers distribute Void on our website and in releases. If you'd like to see the scripts to convert `Mac .app -> .dmg`, `Windows folder -> .exe`, and `Linux folder -> appimage` for distribution, feel free to reach out.
 
 ## Pull Request Guidelines
 
@@ -123,7 +123,7 @@ Void's maintainers distribute Void on our website and in releases. If you'd like
 
 ## Codebase Guide
 
-We highly recommend reading [this](https://github.com/microsoft/vscode/wiki/Source-Code-Organization) article on VSCode's sourcecode organization. 
+We highly recommend reading [this](https://github.com/microsoft/vscode/wiki/Source-Code-Organization) article on VSCode's sourcecode organization.
 
 We are currently putting together our own articles on VSCode and Void's sourcecode organization. The best way to get this information right now is by attending a weekly meeting.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ First, run `npm install -g node-gyp`. Then:
 To build Void, open `void/` inside VSCode. Then open your terminal and run:
 
 1. `npm install` to install all dependencies.
-2. `npm run watchreact` to build Void's browser dependencies like React. (If this doesn't work, try `npm run buildreact`).
+2. `npm run watchreact` to build Void's browser dependencies like React.
 3. Build Void.
 	 - Press <kbd>Cmd+Shift+B</kbd> (Mac).
    - Press <kbd>Ctrl+Shift+B</kbd> (Windows/Linux).

--- a/src/vs/workbench/contrib/void/browser/react/build.js
+++ b/src/vs/workbench/contrib/void/browser/react/build.js
@@ -80,6 +80,22 @@ const args = process.argv.slice(2);
 const isWatch = args.includes('--watch') || args.includes('-w');
 
 if (isWatch) {
+
+	// Check if src2/ exists; if not, do an initial scope-tailwind build
+	if (!fs.existsSync('src2')) {
+		try {
+			console.log('🔨 Running initial scope-tailwind build to create src2 folder...');
+			execSync(
+				'npx scope-tailwind ./src -o src2/ -s void-scope -c styles.css -p "void-"',
+				{ stdio: 'inherit' }
+			);
+			console.log('✅ src2/ created successfully.');
+		} catch (err) {
+			console.error('❌ Error running initial scope-tailwind build:', err);
+			process.exit(1);
+		}
+	}
+
 	// Watch mode
 	const scopeTailwindWatcher = spawn('npx', [
 		'nodemon',

--- a/src/vs/workbench/contrib/void/browser/react/build.js
+++ b/src/vs/workbench/contrib/void/browser/react/build.js
@@ -80,7 +80,7 @@ const args = process.argv.slice(2);
 const isWatch = args.includes('--watch') || args.includes('-w');
 
 if (isWatch) {
-
+	// this just builds it if it doesn't exist instead of waiting for the watcher to trigger
 	// Check if src2/ exists; if not, do an initial scope-tailwind build
 	if (!fs.existsSync('src2')) {
 		try {


### PR DESCRIPTION
### Description: 
Improved the npm run watchreact command:

- Added code in build.js that checks if src2 directory exists already. If not then it runs the scope-taiwind npx script first to create that folder and its contents before setting up the watchers
- Removed the text in Contributions.md saying build if it doesn't work

### Issue:
Resolves the error that occurs when users run `npm run watchreact` for the first time. The issue occurs because the watchers are set up at the same time. The second watcher (which uses tsup) fails because it is **looking for the src2 directory** to watch, which **does not exist yet** as it is being built for the first time by the other watcher (nodemon).