### PR TITLE
fix(build): fixes void-reh (remote host) build crashes and updates the remote-host output path to say void rather than vscode

### DIFF
--- a/build/gulpfile.reh.js
+++ b/build/gulpfile.reh.js
@@ -516,7 +516,7 @@ function tweakProductForServerWeb(product) {
 
 		['', 'min'].forEach(minified => {
 			const sourceFolderName = `out-vscode-${type}${dashed(minified)}`;
-			const destinationFolderName = `vscode-${type}${dashed(platform)}${dashed(arch)}`;
+			const destinationFolderName = `void-${type}${dashed(platform)}${dashed(arch)}`;
 
 			const serverTaskCI = task.define(`vscode-${type}${dashed(platform)}${dashed(arch)}${dashed(minified)}-ci`, task.series(
 				gulp.task(`node-${platform}-${arch}`),

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -38,6 +38,7 @@
         "native-watchdog": "^1.4.1",
         "node-pty": "1.1.0-beta21",
         "tas-client-umd": "0.2.0",
+        "tslib": "^2.8.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
         "vscode-textmate": "9.1.0",
@@ -1034,6 +1035,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/remote/package.json
+++ b/remote/package.json
@@ -33,6 +33,7 @@
     "native-watchdog": "^1.4.1",
     "node-pty": "1.1.0-beta21",
     "tas-client-umd": "0.2.0",
+    "tslib": "^2.8.1",
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",
     "vscode-textmate": "9.1.0",


### PR DESCRIPTION
### Description:
Fixes bugs related to compiling and building void-server or the remote host to be used by **open-remote-ssh extension** by

- Fixes this error:
`Error: Command failed: npm ls --all --omit=dev --parseable
npm ERR! code ELSPROBLEMS
npm ERR! extraneous: @parcel/node-addon-api@ /Users/joaquincoromina/projects/void/react-ssh-extension/void/remote/node_modules/@parcel/node-addon-api
npm ERR! missing: tslib@*, required by @microsoft/applicationinsights-core-js@2.8.15`
which can be replicated by running `npm ls --all --omit=dev --parseable` in **/remote**
- Updating the output directory to be **void-reh-{{PLATFORM}}-{{ARCH}}** instead of vscode-reh-{{PLATFORM}}-{{ARCH}} 

### Issue:
Partially addresses #209  by fixing the compilation process of the void remote host which can then be included in the output files of void-remote-updates, and used by the Remote-SSH extension.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes build issues by adding `tslib` dependency and updates output directory naming to `void-reh` in `remote/package.json`.
> 
>   - **Build Fixes**:
>     - Adds `tslib` dependency to `remote/package.json` to resolve missing dependency error during build.
>     - Updates output directory naming from `vscode-reh-{{PLATFORM}}-{{ARCH}}` to `void-reh-{{PLATFORM}}-{{ARCH}}`.
>   - **Issue Reference**:
>     - Partially addresses issue #209 by fixing the compilation process for the void remote host.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=voideditor%2Fvoid&utm_source=github&utm_medium=referral)<sup> for 6f6f43c46e22e3e03f9ce6ab71b39eb2d8c06f01. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->