### PR TITLE
fix ENOENT error spawn on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@xterm/headless": "^5.6.0-beta.64",
         "@xterm/xterm": "^5.6.0-beta.64",
         "ajv": "^8.17.1",
+        "cross-spawn": "^7.0.6",
         "diff": "^7.0.0",
         "groq-sdk": "^0.9.0",
         "http-proxy-agent": "^7.0.0",
@@ -7116,7 +7117,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -14249,8 +14250,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -17536,7 +17536,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -20241,7 +20240,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -20253,7 +20251,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -23733,7 +23730,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "@xterm/headless": "^5.6.0-beta.64",
     "@xterm/xterm": "^5.6.0-beta.64",
     "ajv": "^8.17.1",
+    "cross-spawn": "^7.0.6",
     "diff": "^7.0.0",
     "groq-sdk": "^0.9.0",
     "http-proxy-agent": "^7.0.0",

--- a/src/vs/workbench/contrib/void/browser/react/build.js
+++ b/src/vs/workbench/contrib/void/browser/react/build.js
@@ -3,7 +3,8 @@
  *  Licensed under the Apache License, Version 2.0. See LICENSE.txt for more information.
  *--------------------------------------------------------------------------------------*/
 
-import { spawn, execSync } from 'child_process';
+import { execSync } from 'child_process';
+import { spawn } from 'cross-spawn'
 // Added lines below
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
This Pull Request was made to handle the following ENOENT error:

![image](https://github.com/user-attachments/assets/16a8c135-7f0c-41f3-ba08-ea2f9e2f924a)

- After a bit of investigating, spawn processes on Windows works differently than Mac/Linux systems, sometimes you have to suffix ".cmd" on the commands, etc. 

To fix this, I use [cross-spawn](https://www.npmjs.com/package/cross-spawn), a popular npm package to handle cross platform spawns and it fixed this issue.

- The only change that was made was to install `cross-spawn` and changed the `spawn` import from `child_process` to `cross-spawn` in the `build.js` file.

- Everything works fine after that and the application ran, and the watch feature in Windows works great.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes ENOENT error on Windows by using `cross-spawn` for process spawning in `build.js`.
> 
>   - **Behavior**:
>     - Fixes ENOENT error on Windows by replacing `child_process.spawn` with `cross-spawn` in `build.js`.
>     - Ensures cross-platform compatibility for spawning processes.
>   - **Dependencies**:
>     - Adds `cross-spawn` to `package.json` dependencies.
>   - **Imports**:
>     - Changes `spawn` import from `child_process` to `cross-spawn` in `build.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=voideditor%2Fvoid&utm_source=github&utm_medium=referral)<sup> for 1839acab1f40fbf44c6e9283850461da5ad3e121. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->