### PR TITLE
Fix encryption service not working on Linux

### DIFF
--- a/src/vs/platform/encryption/electron-main/encryptionMainService.ts
+++ b/src/vs/platform/encryption/electron-main/encryptionMainService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { safeStorage as safeStorageElectron, app } from 'electron';
-import { isMacintosh, isWindows } from '../../../base/common/platform.js';
+import { isMacintosh, isWindows, isLinux } from '../../../base/common/platform.js';
 import { KnownStorageProvider, IEncryptionMainService, PasswordStoreCLIOption } from '../common/encryptionService.js';
 import { ILogService } from '../../log/common/log.js';
 
@@ -23,6 +23,11 @@ export class EncryptionMainService implements IEncryptionMainService {
 	constructor(
 		@ILogService private readonly logService: ILogService
 	) {
+		if (isLinux && !app.commandLine.getSwitchValue('password-store')) {
+			this.logService.trace('[EncryptionMainService] No password-store switch, defaulting to basic...');
+			app.commandLine.appendSwitch('password-store', PasswordStoreCLIOption.basic);
+		}
+
 		// if this commandLine switch is set, the user has opted in to using basic text encryption
 		if (app.commandLine.getSwitchValue('password-store') === PasswordStoreCLIOption.basic) {
 			this.logService.trace('[EncryptionMainService] setting usePlainTextEncryption to true...');


### PR DESCRIPTION
Fixes API keys not storing and providers not working on Linux:
```
[main 2025-02-16T14:41:53.665Z] Error: Error while encrypting the text provided to safeStorage.encryptString. Encryption is not available.
    at EncryptionMainService.encrypt (file:///home/ezwal/Documents/void/out/vs/platform/encryption/electron-main/encryptionMainService.js:31:55)
    at Object.call (file:///home/ezwal/Documents/void/out/vs/base/parts/ipc/common/ipc.js:864:38)
    at ChannelServer.onPromise (file:///home/ezwal/Documents/void/out/vs/base/parts/ipc/common/ipc.js:290:31)
    at ChannelServer.onRawMessage (file:///home/ezwal/Documents/void/out/vs/base/parts/ipc/common/ipc.js:269:29)
    at UniqueContainer.value (file:///home/ezwal/Documents/void/out/vs/base/parts/ipc/common/ipc.js:220:69)
    at Emitter._deliver (file:///home/ezwal/Documents/void/out/vs/base/common/event.js:965:22)
    at Emitter._deliverQueue (file:///home/ezwal/Documents/void/out/vs/base/common/event.js:976:18)
    at Emitter.fire (file:///home/ezwal/Documents/void/out/vs/base/common/event.js:999:18)
    at UniqueContainer.value (file:///home/ezwal/Documents/void/out/vs/base/common/event.js:112:89)
    at Emitter._deliver (file:///home/ezwal/Documents/void/out/vs/base/common/event.js:965:22)
    at Emitter.fire (file:///home/ezwal/Documents/void/out/vs/base/common/event.js:994:18)
    at UniqueContainer.value (file:///home/ezwal/Documents/void/out/vs/base/common/event.js:131:102)
    at Emitter._deliver (file:///home/ezwal/Documents/void/out/vs/base/common/event.js:965:22)
    at Emitter.fire (file:///home/ezwal/Documents/void/out/vs/base/common/event.js:994:18)
    at fn (file:///home/ezwal/Documents/void/out/vs/base/common/event.js:469:40)
    at IpcMainImpl.wrappedListener (file:///home/ezwal/Documents/void/out/vs/base/parts/ipc/electron-main/ipcMain.js:24:17)
    at IpcMainImpl.emit (node:events:519:28)
    at WebContents.<anonymous> (node:electron/js2c/browser_init:2:82563)
    at WebContents.emit (node:events:519:28)
```
- Credential/keychain stores are not commonly available on Linux environments, which prevents saving the API keys and models in the editor configuration.

To fix this, if the user does not provide a default text encryption option, the system will default to the basic encryption method, preventing the error.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes encryption on Linux by defaulting to basic encryption in `EncryptionMainService` when no `password-store` is specified.
> 
>   - **Behavior**:
>     - On Linux, defaults to basic encryption if no `password-store` is specified in `EncryptionMainService`.
>     - Logs a trace message when defaulting to basic encryption.
>   - **Files**:
>     - Changes in `encryptionMainService.ts` to handle Linux-specific encryption behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=voideditor%2Fvoid&utm_source=github&utm_medium=referral)<sup> for a38fc81a583c889d8564c7065ab5b5efddfd2573. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->