### PR TITLE
Fixed default url in package.json since this is used by app

### DIFF
--- a/extensions/open-remote-ssh/package.json
+++ b/extensions/open-remote-ssh/package.json
@@ -71,7 +71,7 @@
           "type": "string",
           "description": "The URL from where the vscode server will be downloaded. You can use the following variables and they will be replaced dynamically:\n- ${quality}: vscode server quality, e.g. stable or insiders\n- ${version}: vscode server version, e.g. 1.69.0\n- ${commit}: vscode server release commit\n- ${arch}: vscode server arch, e.g. x64, armhf, arm64\n- ${release}: release number",
           "scope": "application",
-          "default": "https://github.com/voideditor/${NAME_OF_REPO}/releases/download/${version}.${release}/void-server-${os}-${arch}-${version}.${release}.tar.gz"
+          "default": "https://github.com/voideditor/binaries/releases/download/${version}.${release}/void-reh-${os}-${arch}-${version}.${release}.tar.gz"
         },
         "remote.SSH.remotePlatform": {
           "type": "object",


### PR DESCRIPTION
Updated ${NAME_OF_REPO} to binaries and void-server to void-reh so that open-remote-ssh generates the correct url for server download