### PR TITLE
Updated version argument to get voidVersion

### DIFF
--- a/extensions/open-remote-ssh/src/serverConfig.ts
+++ b/extensions/open-remote-ssh/src/serverConfig.ts
@@ -32,12 +32,13 @@ export async function getVSCodeServerConfig(): Promise<IServerConfig> {
 	const customServerBinaryName = vscode.workspace.getConfiguration('remote.SSH.experimental').get<string>('serverBinaryName', '');
 
 	return {
-		version: vscode.version.replace('-insider', ''),
 		commit: productJson.commit,
 		quality: productJson.quality,
 		release: productJson.release,
 		serverApplicationName: customServerBinaryName || productJson.serverApplicationName,
 		serverDataFolderName: productJson.serverDataFolderName,
-		serverDownloadUrlTemplate: productJson.serverDownloadUrlTemplate
+		serverDownloadUrlTemplate: productJson.serverDownloadUrlTemplate,
+		// Edited for Void
+		version: productJson.voidVersion || vscode.version.replace('-insider', ''), // Try void version first, fallback to vscode version
 	};
 }

--- a/extensions/open-remote-ssh/src/serverConfig.ts
+++ b/extensions/open-remote-ssh/src/serverConfig.ts
@@ -39,7 +39,7 @@ export async function getVSCodeServerConfig(): Promise<IServerConfig> {
 		serverApplicationName: customServerBinaryName || productJson.serverApplicationName,
 		serverDataFolderName: productJson.serverDataFolderName,
 		serverDownloadUrlTemplate: productJson.serverDownloadUrlTemplate,
-		// Edited for Void
+		// Void changed this
 		version: productJson.voidVersion
 	};
 }

--- a/extensions/open-remote-ssh/src/serverConfig.ts
+++ b/extensions/open-remote-ssh/src/serverConfig.ts
@@ -32,6 +32,7 @@ export async function getVSCodeServerConfig(): Promise<IServerConfig> {
 	const customServerBinaryName = vscode.workspace.getConfiguration('remote.SSH.experimental').get<string>('serverBinaryName', '');
 
 	return {
+		// version: vscode.version.replace('-insider', ''),
 		commit: productJson.commit,
 		quality: productJson.quality,
 		release: productJson.release,
@@ -39,6 +40,6 @@ export async function getVSCodeServerConfig(): Promise<IServerConfig> {
 		serverDataFolderName: productJson.serverDataFolderName,
 		serverDownloadUrlTemplate: productJson.serverDownloadUrlTemplate,
 		// Edited for Void
-		version: productJson.voidVersion || vscode.version.replace('-insider', ''), // Try void version first, fallback to vscode version
+		version: productJson.voidVersion
 	};
 }


### PR DESCRIPTION
Fixed serverConfig.ts to pull voidVersion instead of version (vscode base version) and if not available fall back on original functionality.