### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ We don't usually recommend packaging. Instead, you should probably just build. I
 
 ### Windows
 - `npm run gulp vscode-win32-x64` - most common
-- `npm run gulp vscode-win32-ia32`
+- `npm run gulp vscode-win32-arm64`
 
 ### Linux
 - `npm run gulp vscode-linux-x64` - most common

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,6 @@ We don't usually recommend packaging. Instead, you should probably just build. I
 ### Linux
 - `npm run gulp vscode-linux-x64` - most common
 - `npm run gulp vscode-linux-arm64`
-- `npm run gulp vscode-linux-ia32`
 
 
 ### Output

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ We don't usually recommend packaging. Instead, you should probably just build. I
 
 ### Linux
 - `npm run gulp vscode-linux-x64` - most common
-- `npm run gulp vscode-linux-arm`
+- `npm run gulp vscode-linux-arm64`
 - `npm run gulp vscode-linux-ia32`
 
 


### PR DESCRIPTION
`vscode-linux-arm` does not exist as a defined build option. `vscode-linux-arm64` *does* however.