### PR TITLE
Disable VoidIcon in onboarding to prevent UI freeze

### DIFF
--- a/src/vs/workbench/contrib/void/browser/react/src/void-onboarding/VoidOnboarding.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-onboarding/VoidOnboarding.tsx
@@ -590,7 +590,7 @@ const VoidOnboardingContent = () => {
 
 					{/* Slice of Void image */}
 					<div className='max-w-md w-full h-[30vh] mx-auto flex items-center justify-center'>
-						<VoidIcon />
+						{/* <VoidIcon /> */}
 					</div>
 
 

--- a/src/vs/workbench/contrib/void/browser/react/src/void-onboarding/VoidOnboarding.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-onboarding/VoidOnboarding.tsx
@@ -12,6 +12,7 @@ import { ChatMarkdownRender } from '../markdown/ChatMarkdownRender.js';
 import { AddModelInputBox, AnimatedCheckmarkButton, OllamaSetupInstructions, OneClickSwitchButton, SettingsForProvider } from '../void-settings-tsx/Settings.js';
 import { ColorScheme } from '../../../../../../../platform/theme/common/theme.js';
 import ErrorBoundary from '../sidebar-tsx/ErrorBoundary.js';
+import { isLinux } from '../../../../../../../base/common/platform.js';
 
 const OVERRIDE_VALUE = false
 
@@ -590,7 +591,7 @@ const VoidOnboardingContent = () => {
 
 					{/* Slice of Void image */}
 					<div className='max-w-md w-full h-[30vh] mx-auto flex items-center justify-center'>
-						{/* <VoidIcon /> */}
+						{!isLinux && <VoidIcon />}
 					</div>
 
 


### PR DESCRIPTION
@andrewpareles as mentioned on Discord, this specific line of this file is creating a terrible bug on Ubuntu, the app becomes unusable, the screen sometimes flickers, nothing works except the close (X) button top-right.

By simply commenting this line out, everything works perfectly.

===
This PR comments out the `VoidIcon` component in the onboarding screen.

In the current main branch, this component causes **severe UI freeze and flickering** when the onboarding screen is active. Commenting it out fixes the problem without affecting other functionality.

Confirmed working after testing on latest `main`.


