### PR TITLE
Add buttons to copy user message and ai message

### DIFF
--- a/src/vs/workbench/contrib/void/browser/react/src/markdown/ApplyBlockHoverButtons.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/markdown/ApplyBlockHoverButtons.tsx
@@ -70,7 +70,13 @@ export const IconShell1 = ({ onClick, Icon, disabled, className, ...props }: Ico
 
 const COPY_FEEDBACK_TIMEOUT = 1500 // amount of time to say 'Copied!'
 
-export const CopyButton = ({ codeStr, toolTipName }: { codeStr: string | (() => Promise<string> | string), toolTipName: string }) => {
+interface CopyButtonProps {
+	text: string | (() => Promise<string> | string),
+	toolTipName: string,
+	className?: string
+}
+
+export const CopyButton = ({ text, toolTipName, className }: CopyButtonProps) => {
 	const accessor = useAccessor()
 
 	const metricsService = accessor.get('IMetricsService')
@@ -85,15 +91,16 @@ export const CopyButton = ({ codeStr, toolTipName }: { codeStr: string | (() => 
 	}, [copyButtonText])
 
 	const onCopy = useCallback(async () => {
-		clipboardService.writeText(typeof codeStr === 'string' ? codeStr : await codeStr())
+		clipboardService.writeText(typeof text === 'string' ? text : await text())
 			.then(() => { setCopyButtonText(CopyButtonText.Copied) })
 			.catch(() => { setCopyButtonText(CopyButtonText.Error) })
-		metricsService.capture('Copy Code', { length: codeStr.length }) // capture the length only
-	}, [metricsService, clipboardService, codeStr, setCopyButtonText])
+		metricsService.capture('Copy Code', { length: text.length }) // capture the length only
+	}, [metricsService, clipboardService, text, setCopyButtonText])
 
 	return <IconShell1
 		Icon={copyButtonText === CopyButtonText.Copied ? Check : copyButtonText === CopyButtonText.Error ? X : Copy}
 		onClick={onCopy}
+		className={className}
 		{...tooltipPropsForApplyBlock({ tooltipName: toolTipName })}
 	/>
 }
@@ -450,7 +457,7 @@ export const BlockCodeApplyWrapper = ({
 			</div>
 			<div className={`${canApply ? '' : 'hidden'} flex items-center gap-1`}>
 				<JumpToFileButton uri={uri} />
-				{currStreamState === 'idle-no-changes' && <CopyButton codeStr={codeStr} toolTipName='Copy' />}
+				{currStreamState === 'idle-no-changes' && <CopyButton text={codeStr} toolTipName='Copy' />}
 				<ApplyButtonsHTML uri={uri} applyBoxId={applyBoxId} codeStr={codeStr} />
 			</div>
 		</div>

--- a/src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarChat.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarChat.tsx
@@ -1355,7 +1355,7 @@ const AssistantMessageComponent = ({ chatMessage, isCheckpointGhost, isCommitted
 
 		{/* assistant message */}
 		{chatMessage.displayContent &&
-			<div className={`${isCheckpointGhost ? 'opacity-50' : ''}`} onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+			<div className={`relative ${isCheckpointGhost ? 'opacity-50' : ''}`} onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
 				<ProseWrapper>
 					<ChatMarkdownRender
 						string={chatMessage.displayContent || ''}
@@ -1364,8 +1364,10 @@ const AssistantMessageComponent = ({ chatMessage, isCheckpointGhost, isCommitted
 						isLinkDetectionEnabled={true}
 					/>
 				</ProseWrapper>
-				<div className={`flex mt-2 justify-end ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
-					<CopyButton text={chatMessage.displayContent} toolTipName='Copy' />
+				<div className="absolute bottom-0 right-0 h-0 w-0 mb-4 overflow-visible">
+					<div className={`flex justify-end ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+						<CopyButton text={chatMessage.displayContent} toolTipName='Copy' />
+					</div>
 				</div>
 			</div>
 		}

--- a/src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarChat.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarChat.tsx
@@ -1355,10 +1355,7 @@ const AssistantMessageComponent = ({ chatMessage, isCheckpointGhost, isCommitted
 
 		{/* assistant message */}
 		{chatMessage.displayContent &&
-			<div className={`relative ${isCheckpointGhost ? 'opacity-50' : ''}`} onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
-				<div className={`absolute flex -top-1 -right-1 translate-x-0 -translate-y-0 z-1 ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
-					<CopyButton text={chatMessage.displayContent} toolTipName='Copy' />
-				</div>
+			<div className={`${isCheckpointGhost ? 'opacity-50' : ''}`} onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
 				<ProseWrapper>
 					<ChatMarkdownRender
 						string={chatMessage.displayContent || ''}
@@ -1367,6 +1364,9 @@ const AssistantMessageComponent = ({ chatMessage, isCheckpointGhost, isCommitted
 						isLinkDetectionEnabled={true}
 					/>
 				</ProseWrapper>
+				<div className={`flex mt-2 justify-end ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+					<CopyButton text={chatMessage.displayContent} toolTipName='Copy' />
+				</div>
 			</div>
 		}
 	</>

--- a/src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarChat.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarChat.tsx
@@ -1186,15 +1186,24 @@ const UserMessageComponent = ({ chatMessage, messageIdx, isCheckpointGhost, curr
 
 
 		<div
-			className="absolute -top-1 -right-1 translate-x-0 -translate-y-0 z-1"
+			className="absolute flex -top-1 -right-1 gap-1 translate-x-0 -translate-y-0 z-1"
 		// data-tooltip-id='void-tooltip'
 		// data-tooltip-content='Edit message'
 		// data-tooltip-place='left'
 		>
+			<CopyButton
+				className={`
+									bg-void-bg-1 border border-void-border-1 rounded-md
+									transition-opacity duration-200 ease-in-out
+									${isHovered && mode === 'display' ? 'opacity-100' : 'opacity-0 focus:opacity-0'}
+								`}
+				text={chatMessage.displayContent}
+				toolTipName='Copy'
+			/>
 			<EditSymbol
 				size={18}
 				className={`
-                    cursor-pointer
+                    cursor-pointer text-void-fg-3
                     p-[2px]
                     bg-void-bg-1 border border-void-border-1 rounded-md
                     transition-opacity duration-200 ease-in-out
@@ -1310,6 +1319,7 @@ max-w-none
 const AssistantMessageComponent = ({ chatMessage, isCheckpointGhost, isCommitted, messageIdx }: { chatMessage: ChatMessage & { role: 'assistant' }, isCheckpointGhost: boolean, messageIdx: number, isCommitted: boolean }) => {
 
 	const accessor = useAccessor()
+	const [isHovered, setIsHovered] = useState(false);
 	const chatThreadsService = accessor.get('IChatThreadService')
 
 	const reasoningStr = chatMessage.reasoning?.trim() || null
@@ -1345,7 +1355,10 @@ const AssistantMessageComponent = ({ chatMessage, isCheckpointGhost, isCommitted
 
 		{/* assistant message */}
 		{chatMessage.displayContent &&
-			<div className={`${isCheckpointGhost ? 'opacity-50' : ''}`}>
+			<div className={`relative ${isCheckpointGhost ? 'opacity-50' : ''}`} onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+				<div className={`absolute flex -top-1 -right-1 translate-x-0 -translate-y-0 z-1 ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
+					<CopyButton text={chatMessage.displayContent} toolTipName='Copy' />
+				</div>
 				<ProseWrapper>
 					<ChatMarkdownRender
 						string={chatMessage.displayContent || ''}
@@ -1682,7 +1695,7 @@ const EditToolHeaderButtons = ({ applyBoxId, uri, codeStr, toolName, threadId }:
 	return <div className='flex items-center gap-1'>
 		{/* <StatusIndicatorForApplyButton applyBoxId={applyBoxId} uri={uri} /> */}
 		{/* <JumpToFileButton uri={uri} /> */}
-		{streamState === 'idle-no-changes' && <CopyButton codeStr={codeStr} toolTipName='Copy' />}
+		{streamState === 'idle-no-changes' && <CopyButton text={codeStr} toolTipName='Copy' />}
 		<EditToolAcceptRejectButtonsHTML type={toolName} codeStr={codeStr} applyBoxId={applyBoxId} uri={uri} threadId={threadId} />
 	</div>
 }

--- a/src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarThreadSelector.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarThreadSelector.tsx
@@ -187,7 +187,7 @@ const PastThreadElement = ({ pastThread, idx, hoveredIdx, setHoveredIdx, isRunni
 	// const chatMode = settingsState.globalSettings.chatMode
 	// const modelSelection = settingsState.modelSelectionOfFeature?.Chat ?? null
 	// const copyChatButton = <CopyButton
-	// 	codeStr={async () => {
+	// 	text={async () => {
 	// 		const { messages } = await convertService.prepareLLMChatMessages({
 	// 			chatMessages: currentThread.messages,
 	// 			chatMode,
@@ -201,7 +201,7 @@ const PastThreadElement = ({ pastThread, idx, hoveredIdx, setHoveredIdx, isRunni
 
 	// const currentThread = chatThreadsService.getCurrentThread()
 	// const copyChatButton2 = <CopyButton
-	// 	codeStr={async () => {
+	// 	text={async () => {
 	// 		return JSON.stringify(currentThread.messages, null, 2)
 	// 	}}
 	// 	toolTipName={`Copy As Void Chat`}


### PR DESCRIPTION
#236 
This PR adds buttons to copy an AI message and a user message. It implements some, not all, of the tasks in #236.

The AI message copy button appears in the top right corner when a user hovers over the AI message. The user message copy button appears to the right of pencil when a user hovers over the user message in display mode.

https://github.com/user-attachments/assets/f43d1d20-15f2-451c-9c55-e68996345d87

^ the video doesn't capture my cursor properly. But I think it shows the gist of the changes.