### PR TITLE
[Provider] Cohere: [OpenAICompatibleModel Chat + tools]

### DIFF
--- a/src/vs/workbench/contrib/void/browser/react/src/void-onboarding/VoidOnboarding.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-onboarding/VoidOnboarding.tsx
@@ -219,6 +219,14 @@ const AddProvidersPage = ({ pageIndex, setPageIndex }: { pageIndex: number, setP
 								className="ml-1 text-xs align-top text-blue-400"
 							>*</span>
 						)}
+						{providerName === 'cohere' && (
+							<span
+								data-tooltip-id="void-tooltip-provider-info"
+								data-tooltip-content="Cohere offers 1000 free messages a month."
+								data-tooltip-place="right"
+								className="ml-1 text-xs align-top text-blue-400"
+							>*</span>
+						)}
 					</div>
 					<div>
 						<SettingsForProvider providerName={providerName} showProviderTitle={false} showProviderSuggestions={true} />

--- a/src/vs/workbench/contrib/void/common/modelCapabilities.ts
+++ b/src/vs/workbench/contrib/void/common/modelCapabilities.ts
@@ -137,7 +137,7 @@ export const defaultModelsOfProvider = {
 	],
 	cohere: [ // https://docs.cohere.com/docs/models
 		'command-a-03-2025',
-	]
+	],
 	openAICompatible: [], // fallback
 	googleVertex: [],
 	microsoftAzure: [],

--- a/src/vs/workbench/contrib/void/common/modelCapabilities.ts
+++ b/src/vs/workbench/contrib/void/common/modelCapabilities.ts
@@ -45,6 +45,9 @@ export const defaultProviderSettings = {
 	mistral: {
 		apiKey: '',
 	},
+	cohere: {
+		apiKey: '',
+	},
 	lmStudio: {
 		endpoint: 'http://localhost:1234',
 	},
@@ -132,6 +135,9 @@ export const defaultModelsOfProvider = {
 		'ministral-3b-latest',
 		'ministral-8b-latest',
 	],
+	cohere: [ // https://docs.cohere.com/docs/models
+		'command-a-03-2025',
+	]
 	openAICompatible: [], // fallback
 	googleVertex: [],
 	microsoftAzure: [],
@@ -890,6 +896,24 @@ const mistralSettings: VoidStaticProviderInfo = {
 	modelOptionsFallback: (modelName) => { return null },
 }
 
+// ---------------- COHERE ----------------
+
+const cohereModelOptions = { // https://cohere.com/pricing https://docs.cohere.com/docs/models
+	'command-a-03-2025': {
+		contextWindow: 256_000,
+		reservedOutputTokenSpace: 8_192,
+		cost: { input: 2.50, output: 10.0 },
+		supportsFIM: false,
+		downloadable: { sizeGb: 216 },
+		supportsSystemMessage: 'system-role',
+		reasoningCapabilities: false,
+	},
+} as const satisfies { [s: string]: VoidStaticModelInfo }
+
+const cohereSettings: VoidStaticProviderInfo = {
+	modelOptions: cohereModelOptions,
+	modelOptionsFallback: (modelName) => { return null },
+}
 
 // ---------------- GROQ ----------------
 const groqModelOptions = { // https://console.groq.com/docs/models, https://groq.com/pricing/
@@ -1249,6 +1273,7 @@ const modelSettingsOfProvider: { [providerName in ProviderName]: VoidStaticProvi
 	ollama: ollamaSettings,
 	openAICompatible: openaiCompatible,
 	mistral: mistralSettings,
+	cohere: cohereSettings,
 
 	liteLLM: liteLLMSettings,
 	lmStudio: lmStudioSettings,

--- a/src/vs/workbench/contrib/void/common/voidSettingsTypes.ts
+++ b/src/vs/workbench/contrib/void/common/voidSettingsTypes.ts
@@ -97,6 +97,9 @@ export const displayInfoOfProviderName = (providerName: ProviderName): DisplayIn
 	else if (providerName === 'mistral') {
 		return { title: 'Mistral', }
 	}
+	else if (providerName === 'cohere') {
+		return { title: 'Cohere', }
+	}
 	else if (providerName === 'googleVertex') {
 		return { title: 'Google Vertex AI', }
 	}
@@ -117,6 +120,7 @@ export const subTextMdOfProviderName = (providerName: ProviderName): string => {
 	if (providerName === 'groq') return 'Get your [API Key here](https://console.groq.com/keys).'
 	if (providerName === 'xAI') return 'Get your [API Key here](https://console.x.ai).'
 	if (providerName === 'mistral') return 'Get your [API Key here](https://console.mistral.ai/api-keys).'
+	if (providerName === 'cohere') return 'Get your [API Key here](https://dashboard.cohere.com/api-keys).'
 	if (providerName === 'openAICompatible') return `Use any provider that's OpenAI-compatible (use this for llama.cpp and more).`
 	if (providerName === 'googleVertex') return 'You must authenticate before using Vertex with Void. Read more about endpoints [here](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-vertex-using-openai-library), and regions [here](https://cloud.google.com/vertex-ai/docs/general/locations#available-regions).'
 	if (providerName === 'microsoftAzure') return 'Read more about endpoints [here](https://learn.microsoft.com/en-us/rest/api/aifoundry/model-inference/get-chat-completions/get-chat-completions?view=rest-aifoundry-model-inference-2024-05-01-preview&tabs=HTTP), and get your API key [here](https://learn.microsoft.com/en-us/azure/search/search-security-api-keys?tabs=rest-use%2Cportal-find%2Cportal-query#find-existing-keys).'
@@ -151,7 +155,8 @@ export const displayInfoOfSettingName = (providerName: ProviderName, settingName
 											providerName === 'mistral' ? 'api-key...' :
 												providerName === 'googleVertex' ? 'AIzaSy...' :
 													providerName === 'microsoftAzure' ? 'key-...' :
-														'',
+														providerName === 'cohere' ? 'key...' :
+															'',
 
 			isPasswordField: true,
 		}
@@ -284,6 +289,12 @@ export const defaultSettingsOfProvider: SettingsOfProvider = {
 		...defaultCustomSettings,
 		...defaultProviderSettings.mistral,
 		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.mistral),
+		_didFillInProviderSettings: undefined,
+	},
+	mistral: {
+		...defaultCustomSettings,
+		...defaultProviderSettings.cohere,
+		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.cohere),
 		_didFillInProviderSettings: undefined,
 	},
 	liteLLM: {

--- a/src/vs/workbench/contrib/void/common/voidSettingsTypes.ts
+++ b/src/vs/workbench/contrib/void/common/voidSettingsTypes.ts
@@ -291,7 +291,7 @@ export const defaultSettingsOfProvider: SettingsOfProvider = {
 		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.mistral),
 		_didFillInProviderSettings: undefined,
 	},
-	mistral: {
+	cohere: {
 		...defaultCustomSettings,
 		...defaultProviderSettings.cohere,
 		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.cohere),

--- a/src/vs/workbench/contrib/void/electron-main/llmMessage/sendLLMMessage.impl.ts
+++ b/src/vs/workbench/contrib/void/electron-main/llmMessage/sendLLMMessage.impl.ts
@@ -140,6 +140,10 @@ const newOpenAICompatibleSDK = async ({ settingsOfProvider, providerName, includ
 		const thisConfig = settingsOfProvider[providerName]
 		return new OpenAI({ baseURL: 'https://api.mistral.ai/v1', apiKey: thisConfig.apiKey, ...commonPayloadOpts })
 	}
+	else if (providerName === 'cohere') {
+		const thisConfig = settingsOfProvider[providerName]
+		return new OpenAI({ baseURL: 'https://api.cohere.com/compatibility/v1', apiKey: thisConfig.apiKey, ...commonPayloadOpts })
+	}
 
 	else throw new Error(`Void providerName was invalid: ${providerName}.`)
 }
@@ -832,6 +836,11 @@ export const sendLLMMessageToProviderImplementation = {
 	mistral: {
 		sendChat: (params) => _sendOpenAICompatibleChat(params),
 		sendFIM: (params) => sendMistralFIM(params),
+		list: null,
+	},
+	cohere: {
+		sendChat: (params) => _sendOpenAICompatibleChat(params),
+		sendFIM: (params) => _sendOpenAICompatibleFIM(params),
 		list: null,
 	},
 	ollama: {


### PR DESCRIPTION
This PR adds support for Cohere as a model provider via the OpenAI compatibility API, and includes the model `command-a-03-2025`.