### PR TITLE
fix: preserve selection when adding to chat via CTRL+L with closed panel

### DIFF
--- a/src/vs/workbench/contrib/void/browser/sidebarActions.ts
+++ b/src/vs/workbench/contrib/void/browser/sidebarActions.ts
@@ -98,20 +98,20 @@ registerAction2(class extends Action2 {
 
 		metricsService.capture('Ctrl+L', {})
 
-		// Capture selection and model BEFORE opening the chat panel
+		// capture selection and model before opening the chat panel
 		const editor = editorService.getActiveCodeEditor()
 		const model = editor?.getModel()
 		if (!model) return
 
 		const selectionRange = roundRangeToLines(editor?.getSelection(), { emptySelectionBehavior: 'null' })
 
-		// Now check if panel is open and open it if needed
+		// open panel
 		const wasAlreadyOpen = viewsService.isViewContainerVisible(VOID_VIEW_CONTAINER_ID)
 		if (!wasAlreadyOpen) {
 			await commandService.executeCommand(VOID_OPEN_SIDEBAR_ACTION_ID)
 		}
 
-		// Add selection to chat (whether it was already open or we just opened it)
+		// Add selection to chat
 		// add line selection
 		if (selectionRange) {
 			editor?.setSelection({


### PR DESCRIPTION
### Fix: Add to Chat preserves selection when panel is closed
Previously, when using Ctrl+L with a closed chat panel, users had to perform the action twice: once to open the panel, then again to actually add the selection.
Now the selection is captured before opening the panel, eliminating this double work.

Before:

1. Checked if the chat panel was open
2. If closed, opened it and returned early (never capturing selection)
3. Only grabbed selection if the panel was already open

https://github.com/user-attachments/assets/a6c1ba3f-e68e-40e0-9acf-713e10c36595



After:
1. Captures the selection first - before any UI changes
2. Then checks and opens the panel if needed
3. Finally adds the selection to chat in both cases

https://github.com/user-attachments/assets/06736f5a-36b6-48b3-80f0-a861938e40b3

