### PR TITLE
fix: select AzureOpenAI deployment based on selected model

### DIFF
--- a/src/vs/workbench/contrib/void/electron-main/llmMessage/sendLLMMessage.impl.ts
+++ b/src/vs/workbench/contrib/void/electron-main/llmMessage/sendLLMMessage.impl.ts
@@ -116,7 +116,10 @@ const newOpenAICompatibleSDK = async ({ settingsOfProvider, providerName, includ
 		// https://learn.microsoft.com/en-us/rest/api/aifoundry/model-inference/get-chat-completions/get-chat-completions?view=rest-aifoundry-model-inference-2024-05-01-preview&tabs=HTTP
 		//  https://github.com/openai/openai-node?tab=readme-ov-file#microsoft-azure-openai
 		const thisConfig = settingsOfProvider[providerName]
-		return new AzureOpenAI({ apiKey: thisConfig.apiKey, apiVersion: thisConfig.azureApiVersion, project: thisConfig.project, ...commonPayloadOpts })
+		const endpoint = `https://${thisConfig.project}.openai.azure.com/`;
+		const apiVersion = thisConfig.azureApiVersion ?? '2024-04-01-preview';
+		const options = { endpoint, apiKey: thisConfig.apiKey, apiVersion };
+		return new AzureOpenAI({ ...options, ...commonPayloadOpts });
 	}
 
 	else if (providerName === 'deepseek') {
@@ -263,6 +266,10 @@ const _sendOpenAICompatibleChat = async ({ messages, onText, onFinalMessage, onE
 
 	// instance
 	const openai: OpenAI = await newOpenAICompatibleSDK({ providerName, settingsOfProvider, includeInPayload })
+	if (providerName === 'microsoftAzure') {
+		// Required to select the model
+		(openai as AzureOpenAI).deploymentName = modelName;
+	}
 	const options: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
 		model: modelName,
 		messages: messages as any,


### PR DESCRIPTION
As discussed in #369, this specifies the `deploymentName` enabling the AzureOpenAI provider to work as expected. 