### PR TITLE
[Fix] system role for o-series models

### DIFF
--- a/src/vs/workbench/contrib/void/common/modelCapabilities.ts
+++ b/src/vs/workbench/contrib/void/common/modelCapabilities.ts
@@ -374,23 +374,18 @@ const extensiveModelOptionsFallback: VoidStaticProviderInfo['modelOptionsFallbac
 	const lower = modelName.toLowerCase()
 
 	const toFallback = <T extends { [s: string]: Omit<VoidStaticModelInfo, 'cost' | 'downloadable'> },>(obj: T, recognizedModelName: string & keyof T)
-		: VoidStaticModelInfo & { modelName: string, recognizedModelName: string, roleMode: 'system' | 'developer' | false } => {
+		: VoidStaticModelInfo & { modelName: string, recognizedModelName: string } => {
 
-		const opts = obj[recognizedModelName];
-
-		const roleMode =
-			recognizedModelName === 'system' || recognizedModelName === 'gemini'
-				? 'system'
-				: recognizedModelName === 'developer'
-					? 'developer'
-					: false;
+		const opts = obj[recognizedModelName]
+		const supportsSystemMessage = opts.supportsSystemMessage === 'separated'
+			? 'system-role'
+			: opts.supportsSystemMessage
 
 		return {
 			recognizedModelName,
 			modelName,
 			...opts,
-			supportsSystemMessage: roleMode !== false,
-			roleMode,
+			supportsSystemMessage: supportsSystemMessage,
 			cost: { input: 0, output: 0 },
 			downloadable: false,
 			...fallbackKnownValues

--- a/src/vs/workbench/contrib/void/common/modelCapabilities.ts
+++ b/src/vs/workbench/contrib/void/common/modelCapabilities.ts
@@ -374,19 +374,29 @@ const extensiveModelOptionsFallback: VoidStaticProviderInfo['modelOptionsFallbac
 	const lower = modelName.toLowerCase()
 
 	const toFallback = <T extends { [s: string]: Omit<VoidStaticModelInfo, 'cost' | 'downloadable'> },>(obj: T, recognizedModelName: string & keyof T)
-		: VoidStaticModelInfo & { modelName: string, recognizedModelName: string } => {
+		: VoidStaticModelInfo & { modelName: string, recognizedModelName: string, roleMode: 'system' | 'developer' | false } => {
 
-		const opts = obj[recognizedModelName]
+		const opts = obj[recognizedModelName];
+
+		const roleMode =
+			recognizedModelName === 'system' || recognizedModelName === 'gemini'
+				? 'system'
+				: recognizedModelName === 'developer'
+					? 'developer'
+					: false;
+
 		return {
 			recognizedModelName,
 			modelName,
 			...opts,
-			supportsSystemMessage: opts.supportsSystemMessage ?? false,
+			supportsSystemMessage: roleMode !== false,
+			roleMode,
 			cost: { input: 0, output: 0 },
 			downloadable: false,
 			...fallbackKnownValues
-		}
+		};
 	}
+
 	if (lower.includes('gemini') && (lower.includes('2.5') || lower.includes('2-5'))) return toFallback(geminiModelOptions, 'gemini-2.5-pro-exp-03-25')
 
 	if (lower.includes('claude-3-5') || lower.includes('claude-3.5')) return toFallback(anthropicModelOptions, 'claude-3-5-sonnet-20241022')

--- a/src/vs/workbench/contrib/void/common/modelCapabilities.ts
+++ b/src/vs/workbench/contrib/void/common/modelCapabilities.ts
@@ -381,7 +381,7 @@ const extensiveModelOptionsFallback: VoidStaticProviderInfo['modelOptionsFallbac
 			recognizedModelName,
 			modelName,
 			...opts,
-			supportsSystemMessage: opts.supportsSystemMessage ? 'system-role' : false,
+			supportsSystemMessage: opts.supportsSystemMessage ?? false,
 			cost: { input: 0, output: 0 },
 			downloadable: false,
 			...fallbackKnownValues


### PR DESCRIPTION
This PR fixes the prompt role issue for O-Series models (o4-mini and o3), which were previously receiving "role": "system". As per the OpenAI docs, these models should use "role": "developer".

Updated the role to "developer" for these models to align with the OpenAI specification.

The fix has been tested successfully. Please refer to the attached screenshot showcasing the correct prompt role in the API request after the change.
![image (1)](https://github.com/user-attachments/assets/dab4f945-b642-4e27-9d42-40ce1662914b)

