### PR TITLE
feat: add import profiles from editors in void settings

### DIFF
--- a/src/vs/workbench/contrib/void/browser/profileTransferService.ts
+++ b/src/vs/workbench/contrib/void/browser/profileTransferService.ts
@@ -1,0 +1,197 @@
+/*--------------------------------------------------------------------------------------
+ *  Copyright 2025 Glass Devtools, Inc. All rights reserved.
+ *  Licensed under the Apache License, Version 2.0. See LICENSE.txt for more information.
+ *--------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { env } from '../../../../base/common/process.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IHostService } from '../../../services/host/browser/host.js';
+import { TransferEditorType, TransferFilesInfo } from './extensionTransferTypes.js';
+
+export interface IProfileTransferService {
+	readonly _serviceBrand: undefined; // services need this, just leave it undefined
+	transferProfiles(os: 'mac' | 'windows' | 'linux' | null, fromEditor: TransferEditorType): Promise<string | undefined>
+}
+
+export const IProfileTransferService = createDecorator<IProfileTransferService>('ProfileTransferService');
+
+
+
+class ProfileTransferService extends Disposable implements IProfileTransferService {
+	_serviceBrand: undefined;
+
+	constructor(
+		@IFileService private readonly _fileService: IFileService,
+		@IHostService private readonly _hostService: IHostService,
+		@IDialogService private readonly _dialogService: IDialogService,
+	) {
+		super()
+	}
+
+	async transferProfiles(os: 'mac' | 'windows' | 'linux' | null, fromEditor: TransferEditorType): Promise<string | undefined> {
+		const transferTheseFiles = transferTheseFilesOfOS(os, fromEditor)
+		const fileService = this._fileService
+
+		let errAcc = ''
+
+		for (const { from, to } of transferTheseFiles) {
+			// Check if the source file exists before attempting to copy
+			try {
+				console.log("Transferring profile from", from, "to", to)
+
+				const exists = await fileService.exists(from)
+				if (exists) {
+					// Ensure the destination directory exists
+					const toParent = URI.joinPath(to, '..')
+					const toParentExists = await fileService.exists(toParent)
+					if (!toParentExists) {
+						await fileService.createFolder(toParent)
+					}
+					await fileService.copy(from, to, true)
+				} else {
+					console.log(`Skipping file that doesn't exist: ${from.toString()}`)
+				}
+			}
+
+			catch (e) {
+				console.error('Error copying file:', e)
+				errAcc += `Error copying ${from.toString()}: ${e}\n`
+			}
+		}
+
+		if (errAcc) return errAcc
+
+		const { confirmed } = await this._dialogService.confirm({
+			title: `Profiles transferred successfully from ${fromEditor}`,
+			message: `Would you like to relaunch Void? \nOtherwise the new profiles will be loaded when you next open Void.`,
+			primaryButton: 'Relaunch',
+			cancelButton: 'Later',
+		})
+
+		if (confirmed) {
+			setTimeout(() => {
+				this._hostService.restart()
+			}, 1000)
+		}
+
+		return undefined
+	}
+}
+
+
+registerSingleton(IProfileTransferService, ProfileTransferService, InstantiationType.Eager); // lazily loaded, even if Eager
+
+
+
+
+
+
+
+
+
+const transferTheseFilesOfOS = (os: 'mac' | 'windows' | 'linux' | null, fromEditor: TransferEditorType = 'VS Code'): TransferFilesInfo => {
+	if (os === null)
+		throw new Error(`One-click switch is not possible in this environment.`)
+	if (os === 'mac') {
+		const homeDir = env['HOME']
+		if (!homeDir) throw new Error(`$HOME not found`)
+
+		if (fromEditor === 'VS Code') {
+			return [{
+				from: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, 'Library', 'Application Support', 'Code', 'User', 'profiles'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, 'Library', 'Application Support', 'Void', 'User', 'profiles'),
+			}, {
+				from: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, 'Library', 'Application Support', 'Code', 'User', 'globalStorage'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, 'Library', 'Application Support', 'Void', 'User', 'globalStorage'),
+			}]
+		} else if (fromEditor === 'Cursor') {
+			return [{
+				from: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, 'Library', 'Application Support', 'Cursor', 'User', 'profiles'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, 'Library', 'Application Support', 'Void', 'User', 'profiles'),
+			}, {
+				from: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, 'Library', 'Application Support', 'Cursor', 'User', 'globalStorage'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, 'Library', 'Application Support', 'Void', 'User', 'globalStorage'),
+			}]
+		} else if (fromEditor === 'Windsurf') {
+			return [{
+				from: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, 'Library', 'Application Support', 'Windsurf', 'User', 'profiles'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, 'Library', 'Application Support', 'Void', 'User', 'profiles'),
+			}, {
+				from: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, 'Library', 'Application Support', 'Windsurf', 'User', 'globalStorage'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, 'Library', 'Application Support', 'Void', 'User', 'globalStorage'),
+			}]
+		}
+	}
+
+	if (os === 'linux') {
+		const homeDir = env['HOME']
+		if (!homeDir) throw new Error(`variable for $HOME location not found`)
+
+		if (fromEditor === 'VS Code') {
+			return [{
+				from: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, '.config', 'Code', 'User', 'profiles'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, '.config', 'Void', 'User', 'profiles'),
+			}, {
+				from: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, '.config', 'Code', 'User', 'globalStorage'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, '.config', 'Void', 'User', 'globalStorage'),
+			}]
+		} else if (fromEditor === 'Cursor') {
+			return [{
+				from: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, '.config', 'Cursor', 'User', 'profiles'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, '.config', 'Void', 'User', 'profiles'),
+			}, {
+				from: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, '.config', 'Cursor', 'User', 'globalStorage'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, '.config', 'Void', 'User', 'globalStorage'),
+			}]
+		} else if (fromEditor === 'Windsurf') {
+			return [{
+				from: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, '.config', 'Windsurf', 'User', 'profiles'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, '.config', 'Void', 'User', 'profiles'),
+			}, {
+				from: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, '.config', 'Windsurf', 'User', 'globalStorage'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), homeDir, '.config', 'Void', 'User', 'globalStorage'),
+			}]
+		}
+	}
+
+	if (os === 'windows') {
+		const appdata = env['APPDATA']
+		if (!appdata) throw new Error(`variable for %APPDATA% location not found`)
+		const userprofile = env['USERPROFILE']
+		if (!userprofile) throw new Error(`variable for %USERPROFILE% location not found`)
+
+		if (fromEditor === 'VS Code') {
+			return [{
+				from: URI.joinPath(URI.from({ scheme: 'file' }), appdata, 'Code', 'User', 'profiles'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), appdata, 'code-oss-dev', 'User', 'profiles'), // Change this to Void
+			}, {
+				from: URI.joinPath(URI.from({ scheme: 'file' }), appdata, 'Code', 'User', 'globalStorage'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), appdata, 'code-oss-dev', 'temp_global', 'globalStorage'), // Change this to Void
+			}]
+		} else if (fromEditor === 'Cursor') {
+			return [{
+				from: URI.joinPath(URI.from({ scheme: 'file' }), appdata, 'Cursor', 'User', 'profiles'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), appdata, 'code-oss-dev', 'User', 'profiles'), // Change this to Void
+			}, {
+				from: URI.joinPath(URI.from({ scheme: 'file' }), appdata, 'Cursor', 'User', 'globalStorage'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), appdata, 'code-oss-dev', 'User', 'globalStorage'), // Change this to Void
+			}]
+		} else if (fromEditor === 'Windsurf') {
+			return [{
+				from: URI.joinPath(URI.from({ scheme: 'file' }), appdata, 'Windsurf', 'User', 'profiles'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), appdata, 'code-oss-dev', 'User', 'profiles'), // Change this to Void
+			}, {
+				from: URI.joinPath(URI.from({ scheme: 'file' }), appdata, 'Windsurf', 'User', 'globalStorage'),
+				to: URI.joinPath(URI.from({ scheme: 'file' }), appdata, 'code-oss-dev', 'User', 'globalStorage'), // Change this to Void
+			}]
+		}
+	}
+
+	throw new Error(`os '${os}' not recognized or editor type '${fromEditor}' not supported for this OS`)
+}
+

--- a/src/vs/workbench/contrib/void/browser/react/src/util/services.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/util/services.tsx
@@ -22,6 +22,7 @@ import { ILLMMessageService } from '../../../../common/sendLLMMessageService.js'
 import { IRefreshModelService } from '../../../../../../../workbench/contrib/void/common/refreshModelService.js';
 import { IVoidSettingsService } from '../../../../../../../workbench/contrib/void/common/voidSettingsService.js';
 import { IExtensionTransferService } from '../../../../../../../workbench/contrib/void/browser/extensionTransferService.js'
+import { IProfileTransferService } from '../../../../../../../workbench/contrib/void/browser/profileTransferService.js'
 
 import { IInstantiationService } from '../../../../../../../platform/instantiation/common/instantiation.js'
 import { ICodeEditorService } from '../../../../../../../editor/browser/services/codeEditorService.js'
@@ -215,6 +216,7 @@ const getReactAccessor = (accessor: ServicesAccessor) => {
 		ITerminalService: accessor.get(ITerminalService),
 		IExtensionManagementService: accessor.get(IExtensionManagementService),
 		IExtensionTransferService: accessor.get(IExtensionTransferService),
+		IProfileTransferService: accessor.get(IProfileTransferService),
 
 	} as const
 	return reactAccessor

--- a/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
@@ -895,6 +895,44 @@ export const OneClickSwitchButton = ({ fromEditor = 'VS Code', className = '' }:
 	</>
 }
 
+export const ImportProfilesButton = ({ fromEditor = 'VS Code', className = '' }: { fromEditor?: TransferEditorType, className?: string }) => {
+	const accessor = useAccessor()
+	const profileTransferService = accessor.get('IProfileTransferService')
+
+	const [transferState, setTransferState] = useState<{ type: 'done', error?: string } | { type: | 'loading' | 'justfinished' }>({ type: 'done' })
+
+
+
+	const onClick = async () => {
+		if (transferState.type !== 'done') return
+
+		setTransferState({ type: 'loading' })
+
+		const errAcc = await profileTransferService.transferProfiles(os, fromEditor)
+
+		// Even if some files were missing, consider it a success if no actual errors occurred
+		const hadError = !!errAcc
+		if (hadError) {
+			setTransferState({ type: 'done', error: errAcc })
+		}
+		else {
+			setTransferState({ type: 'justfinished' })
+			setTimeout(() => { setTransferState({ type: 'done' }); }, 3000)
+		}
+	}
+
+	return <>
+		<VoidButtonBgDarken className={`max-w-48 p-4 ${className}`} disabled={transferState.type !== 'done'} onClick={onClick}>
+			{transferState.type === 'done' ? `Transfer profiles from ${fromEditor}`
+				: transferState.type === 'loading' ? <span className='text-nowrap flex flex-nowrap'>Transferring<IconLoading /></span>
+					: transferState.type === 'justfinished' ? <AnimatedCheckmarkButton text='Profiles Transferred' className='bg-none' />
+						: null
+			}
+		</VoidButtonBgDarken>
+		{transferState.type === 'done' && transferState.error ? <WarningBox text={transferState.error} /> : null}
+	</>
+}
+
 
 // full settings
 
@@ -1167,6 +1205,20 @@ export const Settings = () => {
 							<OneClickSwitchButton className='w-48' fromEditor="VS Code" />
 							<OneClickSwitchButton className='w-48' fromEditor="Cursor" />
 							<OneClickSwitchButton className='w-48' fromEditor="Windsurf" />
+						</div>
+					</ErrorBoundary>
+				</div>
+
+				{/* Import Profiles section */}
+				<div className='mt-12'>
+					<ErrorBoundary>
+						<h2 className='text-3xl mb-2 mt-12'>Import Profiles</h2>
+						<h4 className='text-void-fg-3 mb-4'>{`Transfer your profiles into Void.`}</h4>
+
+						<div className='flex flex-col gap-2'>
+							<ImportProfilesButton className='w-48' fromEditor="VS Code" />
+							<ImportProfilesButton className='w-48' fromEditor="Cursor" />
+							<ImportProfilesButton className='w-48' fromEditor="Windsurf" />
 						</div>
 					</ErrorBoundary>
 				</div>


### PR DESCRIPTION
## Description
This PR includes importing profiles from other editors (VS code, Cursor, Windsurf) to Void.

## 🔧 Changes Made:
- Added profile transfer service 
- Profiles would be stored in staged area, before restart in main process Void's `state.vscdb` keys will be transferred to staged(temp_storage) `state.vscdb` and then all the settings would be transferred (This step is important as when the main process is not in the memory we can access Void's state.vscdb and transfer the keys)
- Shows a dialog to relaunch the application or the profiles will be loaded next time they open Void

## Resolves

Closes #473 