### PR TITLE
Fix keymap for Void: Quick Edit to resolve conflict

### DIFF
--- a/src/vs/workbench/contrib/void/browser/quickEditActions.ts
+++ b/src/vs/workbench/contrib/void/browser/quickEditActions.ts
@@ -42,6 +42,7 @@ registerAction2(class extends Action2 {
 			keybinding: {
 				primary: KeyMod.CtrlCmd | KeyCode.KeyK,
 				weight: KeybindingWeight.VoidExtension,
+				when: 'editorFocus && !terminalFocus',
 			}
 		});
 	}


### PR DESCRIPTION
The current keymap causes a conflict between 'Void: Quick Edit' and 'Clear Console'/'Clear Terminal'. Using this _when_ expression, we can resolve the conflict without affecting functionality. 

* Add the when expression `editorFocus && !terminalFocus` to the keybinding for 'Void: Quick Edit' `void.ctrlKAction`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/voideditor/void/pull/633?shareId=c84ce32e-9253-4e44-afdf-dbd790c8e77a).