### PR TITLE
chore: add grok mini and fast models to dropdown options

### DIFF
--- a/src/vs/workbench/contrib/void/common/modelCapabilities.ts
+++ b/src/vs/workbench/contrib/void/common/modelCapabilities.ts
@@ -86,6 +86,9 @@ export const defaultModelsOfProvider = {
 	xAI: [ // https://docs.x.ai/docs/models?cluster=us-east-1
 		'grok-2',
 		'grok-3',
+		'grok-3-mini',
+		'grok-3-fast',
+		'grok-3-mini-fast'
 	],
 	gemini: [ // https://ai.google.dev/gemini-api/docs/models/gemini
 		'gemini-2.5-pro-exp-03-25',


### PR DESCRIPTION
Adds the ability for users to select some of the other grok models in the chat dropdown.
The model capabilities for them is already up to date as of 23 May 25.

This is linked to keeping models updated issue: https://github.com/voideditor/void/issues/446