### PR TITLE
feat(settings): add “All Settings” tab + smooth-scroll navigation

### DIFF
--- a/src/vs/workbench/contrib/void/browser/chatThreadService.ts
+++ b/src/vs/workbench/contrib/void/browser/chatThreadService.ts
@@ -641,7 +641,7 @@ class ChatThreadService extends Disposable implements IChatThreadService {
 
 			// 2. if tool requires approval, break from the loop, awaiting approval
 
-			const approvalType = isBuiltInTool ? approvalTypeOfBuiltinToolName[toolName] : 'mcp-tools'
+			const approvalType = isBuiltInTool ? approvalTypeOfBuiltinToolName[toolName] : 'MCP tools'
 			if (approvalType) {
 				const autoApprove = this._settingsService.state.globalSettings.autoApprove[approvalType]
 				// add a tool_request because we use it for UI if a tool is loading (this should be improved in the future)

--- a/src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarChat.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarChat.tsx
@@ -1616,7 +1616,7 @@ const ToolRequestAcceptRejectButtons = ({ toolName }: { toolName: ToolName }) =>
 		</button>
 	)
 
-	const approvalType = isABuiltinToolName(toolName) ? approvalTypeOfBuiltinToolName[toolName] : 'mcp-tools'
+	const approvalType = isABuiltinToolName(toolName) ? approvalTypeOfBuiltinToolName[toolName] : 'MCP tools'
 	const approvalToggle = approvalType ? <div key={approvalType} className="flex items-center ml-2 gap-x-1">
 		<ToolApprovalTypeSwitch size='xs' approvalType={approvalType} desc={`Auto-approve ${approvalType}`} />
 	</div> : null

--- a/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
@@ -1037,8 +1037,8 @@ export const Settings = () => {
 		{ tab: 'localProviders', label: 'Local Providers' },
 		{ tab: 'providers', label: 'Other Providers' },
 		{ tab: 'featureOptions', label: 'Feature Options' },
-		{ tab: 'mcp', label: 'MCP' },
 		{ tab: 'general', label: 'General' },
+		{ tab: 'mcp', label: 'MCP' },
 		{ tab: 'all', label: 'All Settings' },
 	];
 	const shouldShowTab = (tab: Tab) => selectedSection === 'all' || selectedSection === tab;
@@ -1345,27 +1345,6 @@ export const Settings = () => {
 								</ErrorBoundary>
 							</div>
 
-							{/* MCP section */}
-							<div className={shouldShowTab('mcp') ? `` : 'hidden'}>
-								<ErrorBoundary>
-									<h2 className='text-3xl mb-2'>MCP</h2>
-									<h4 className={`text-void-fg-3 mb-4`}>
-										<ChatMarkdownRender inPTag={true} string={`
-Use Model Context Protocol to provide Agent mode with more tools.
-							`} chatMessageLocation={undefined} />
-									</h4>
-									<div className='my-2'>
-										<VoidButtonBgDarken className='px-4 py-1 w-full max-w-48' onClick={async () => { await mcpService.revealMCPConfigFile() }}>
-											Add MCP Server
-										</VoidButtonBgDarken>
-									</div>
-
-									<ErrorBoundary>
-										<MCPServersList />
-									</ErrorBoundary>
-								</ErrorBoundary>
-							</div>
-
 							{/* General section */}
 							<div className={`${shouldShowTab('general') ? `` : 'hidden'} flex flex-col gap-12`}>
 								{/* One-Click Switch section */}
@@ -1476,6 +1455,33 @@ Alternatively, place a \`.voidrules\` file in the root of your workspace.
 									</div>
 								</div>
 							</div>
+
+
+
+							{/* MCP section */}
+							<div className={shouldShowTab('mcp') ? `` : 'hidden'}>
+								<ErrorBoundary>
+									<h2 className='text-3xl mb-2'>MCP</h2>
+									<h4 className={`text-void-fg-3 mb-4`}>
+										<ChatMarkdownRender inPTag={true} string={`
+Use Model Context Protocol to provide Agent mode with more tools.
+							`} chatMessageLocation={undefined} />
+									</h4>
+									<div className='my-2'>
+										<VoidButtonBgDarken className='px-4 py-1 w-full max-w-48' onClick={async () => { await mcpService.revealMCPConfigFile() }}>
+											Add MCP Server
+										</VoidButtonBgDarken>
+									</div>
+
+									<ErrorBoundary>
+										<MCPServersList />
+									</ErrorBoundary>
+								</ErrorBoundary>
+							</div>
+
+
+
+
 
 						</div>
 

--- a/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
@@ -23,12 +23,12 @@ import { TransferEditorType, TransferFilesInfo } from '../../../extensionTransfe
 //  Sidebar navigation helpers
 // ─────────────────────────────────────────────
 type SectionKey =
-  | 'models'
-  | 'localProviders'
-  | 'providers'
-  | 'featureOptions'
-  | 'general'
-  | 'all';
+	| 'models'
+	| 'localProviders'
+	| 'providers'
+	| 'featureOptions'
+	| 'general'
+	| 'all';
 
 const ButtonLeftTextRightOption = ({ text, leftButton }: { text: string, leftButton?: React.ReactNode }) => {
 
@@ -910,19 +910,19 @@ export const OneClickSwitchButton = ({ fromEditor = 'VS Code', className = '' }:
 
 export const Settings = () => {
 	const isDark = useIsDark()
-  // ─── sidebar nav ──────────────────────────
-  const [selectedSection, setSelectedSection] =
-    useState<SectionKey>('models');
+	// ─── sidebar nav ──────────────────────────
+	const [selectedSection, setSelectedSection] =
+		useState<SectionKey>('models');
 
-  const navItems: { key: SectionKey; label: string }[] = [
-    { key: 'models',         label: 'Models' },
-    { key: 'localProviders', label: 'Local Providers' },
-    { key: 'providers',      label: 'Providers' },
-    { key: 'featureOptions', label: 'Feature Options' },
-    { key: 'general',        label: 'General' },
-    { key: 'all',            label: 'All Settings' },
-  ];
-    const show = (key: SectionKey) => selectedSection === 'all' || selectedSection === key;
+	const navItems: { key: SectionKey; label: string }[] = [
+		{ key: 'models', label: 'Models' },
+		{ key: 'localProviders', label: 'Local Providers' },
+		{ key: 'providers', label: 'Providers' },
+		{ key: 'featureOptions', label: 'Feature Options' },
+		{ key: 'general', label: 'General' },
+		{ key: 'all', label: 'All Settings' },
+	];
+	const show = (key: SectionKey) => selectedSection === 'all' || selectedSection === key;
 	const accessor = useAccessor()
 	const commandService = accessor.get('ICommandService')
 	const environmentService = accessor.get('IEnvironmentService')
@@ -997,334 +997,334 @@ export const Settings = () => {
 
 
 	return (
-  <div className={`@@void-scope ${isDark ? 'dark' : ''}`} style={{ height: '100%', width: '100%' }}>
-    <div className="flex flex-col md:flex-row w-full h-[80vh] gap-6 max-w-[900px] mx-auto">
-      {/* ──────────────  SIDEBAR  ────────────── */}
+		<div className={`@@void-scope ${isDark ? 'dark' : ''}`} style={{ height: '100%', width: '100%' }}>
+			<div className="flex flex-col md:flex-row w-full h-[80vh] gap-6 max-w-[900px] mx-auto">
+				{/* ──────────────  SIDEBAR  ────────────── */}
 
-<aside className="md:w-1/4 w-full p-6 shrink-0 overflow-y-auto">
-  {/* vertical tab list */}
-  <div className="flex flex-col gap-2">
-    {navItems.map(({ key, label }) => (
-      <button
-        key={key}
-               onClick={() => {
-          if (key === 'all') {
-          setSelectedSection('all');
-            window.scrollTo({ top: 0, behavior: 'smooth' });
-          } else {
-            setSelectedSection(key);
-          }
-        }}
-        className={`
+				<aside className="md:w-1/4 w-full p-6 shrink-0 overflow-y-auto">
+					{/* vertical tab list */}
+					<div className="flex flex-col gap-2">
+						{navItems.map(({ key, label }) => (
+							<button
+								key={key}
+								onClick={() => {
+									if (key === 'all') {
+										setSelectedSection('all');
+										window.scrollTo({ top: 0, behavior: 'smooth' });
+									} else {
+										setSelectedSection(key);
+									}
+								}}
+								className={`
           py-2 px-4 rounded-md text-left transition-all duration-200
           ${selectedSection === key
-            ? 'bg-[#0e70c0]/80 text-white font-medium shadow-sm'
-            : 'bg-void-bg-2 hover:bg-void-bg-2/80 text-void-fg-1'}
+										? 'bg-[#0e70c0]/80 text-white font-medium shadow-sm'
+										: 'bg-void-bg-2 hover:bg-void-bg-2/80 text-void-fg-1'}
         `}
-      >
-        {label}
-      </button>
-    ))}
-  </div>
-</aside>
-
-      {/* ───────────── MAIN PANE ───────────── */}
-      <main className="flex-1 overflow-y-auto p-6 select-none">
-
-
-
-			<div className='max-w-3xl'>
-
-				<h1 className='text-2xl w-full'>{`Void's Settings`}</h1>
-
-				<div className='w-full h-[1px] my-2' />
-
-				{/* Models section (formerly FeaturesTab) */}
-				<ErrorBoundary>
-					<RedoOnboardingButton />
-				</ErrorBoundary>
-
-				<div className='w-full h-[1px] my-4' />
-
-				{/* Models section (formerly FeaturesTab) */}
-				<ErrorBoundary>
-{show('models') && (
-<>
-					<h2 className={`text-3xl mb-2`}>Models</h2>
-					<ModelDump />
-					<div className='w-full h-[1px] my-4' />
-					<AutoDetectLocalModelsToggle />
-					<RefreshableModels />
-    </>
-  )}
-				</ErrorBoundary>
-{show('localProviders') && (
-  <ErrorBoundary>
-    <>
-
-				<h2 className={`text-3xl mb-2 mt-12`}>Local Providers</h2>
-				<h3 className={`text-void-fg-3 mb-2`}>{`Void can access any model that you host locally. We automatically detect your local models by default.`}</h3>
-
-				<div className='opacity-80 mb-4'>
-					<OllamaSetupInstructions sayWeAutoDetect={true} />
-				</div>
-
-
-					<VoidProviderSettings providerNames={localProviderNames} />
-				    </>
-  </ErrorBoundary>
-)}
-{show('providers') && (
-  <ErrorBoundary>
-    <>
-				<h2 className={`text-3xl mb-2 mt-12`}>Providers</h2>
-				<h3 className={`text-void-fg-3 mb-2`}>{`Void can access models from Anthropic, OpenAI, OpenRouter, and more.`}</h3>
-
-					<VoidProviderSettings providerNames={nonlocalProviderNames} />
-				    </>
-  </ErrorBoundary>
-)}
-
-
-{show('featureOptions') && (
-  <ErrorBoundary>
-    <>
-				<h2 className={`text-3xl mt-12`}>Feature Options</h2>
-
-				<div className='flex flex-col gap-y-8 my-4'>
-					<ErrorBoundary>
-						{/* FIM */}
-						<div>
-							<h4 className={`text-base`}>{displayInfoOfFeatureName('Autocomplete')}</h4>
-							<div className='text-sm italic text-void-fg-3 mt-1'>
-								<span>
-									Experimental.{' '}
-								</span>
-								<span
-									className='hover:brightness-110'
-									data-tooltip-id='void-tooltip'
-									data-tooltip-content='We recommend using the largest qwen2.5-coder model you can with Ollama (try qwen2.5-coder:3b).'
-									data-tooltip-class-name='void-max-w-[20px]'
-								>
-									Only works with FIM models.*
-								</span>
-							</div>
-
-							<div className='my-2'>
-								{/* Enable Switch */}
-								<ErrorBoundary>
-									<div className='flex items-center gap-x-2 my-2'>
-										<VoidSwitch
-											size='xs'
-											value={settingsState.globalSettings.enableAutocomplete}
-											onChange={(newVal) => voidSettingsService.setGlobalSetting('enableAutocomplete', newVal)}
-										/>
-										<span className='text-void-fg-3 text-xs pointer-events-none'>{settingsState.globalSettings.enableAutocomplete ? 'Enabled' : 'Disabled'}</span>
-									</div>
-								</ErrorBoundary>
-
-								{/* Model Dropdown */}
-								<ErrorBoundary>
-									<div className={`my-2 ${!settingsState.globalSettings.enableAutocomplete ? 'hidden' : ''}`}>
-										<ModelDropdown featureName={'Autocomplete'} className='text-xs text-void-fg-3 bg-void-bg-1 border border-void-border-1 rounded p-0.5 px-1' />
-									</div>
-								</ErrorBoundary>
-
-							</div>
-
-						</div>
-					</ErrorBoundary>
-
-					{/* Apply */}
-					<ErrorBoundary>
-
-						<div className='w-full'>
-							<h4 className={`text-base`}>{displayInfoOfFeatureName('Apply')}</h4>
-							<div className='text-sm italic text-void-fg-3 mt-1'>Settings that control the behavior of the Apply button.</div>
-
-							<div className='my-2'>
-								{/* Sync to Chat Switch */}
-								<div className='flex items-center gap-x-2 my-2'>
-									<VoidSwitch
-										size='xs'
-										value={settingsState.globalSettings.syncApplyToChat}
-										onChange={(newVal) => voidSettingsService.setGlobalSetting('syncApplyToChat', newVal)}
-									/>
-									<span className='text-void-fg-3 text-xs pointer-events-none'>{settingsState.globalSettings.syncApplyToChat ? 'Same as Chat model' : 'Different model'}</span>
-								</div>
-
-								{/* Model Dropdown */}
-								<div className={`my-2 ${settingsState.globalSettings.syncApplyToChat ? 'hidden' : ''}`}>
-									<ModelDropdown featureName={'Apply'} className='text-xs text-void-fg-3 bg-void-bg-1 border border-void-border-1 rounded p-0.5 px-1' />
-								</div>
-							</div>
-
-
-							<div className='my-2'>
-								{/* Fast Apply Method Dropdown */}
-								<div className='flex items-center gap-x-2 my-2'>
-									<FastApplyMethodDropdown />
-								</div>
-							</div>
-
-						</div>
-					</ErrorBoundary>
-
-
-
-
-					{/* Tools Section */}
-					<div>
-						<h4 className={`text-base`}>Tools</h4>
-						<div className='text-sm italic text-void-fg-3 mt-1'>{`Tools are functions that LLMs can call. Some tools require user approval.`}</div>
-
-						<div className='my-2'>
-							{/* Auto Accept Switch */}
-							<ErrorBoundary>
-								{[...toolApprovalTypes].map((approvalType) => {
-									return <div key={approvalType} className="flex items-center gap-x-2 my-2">
-										<ToolApprovalTypeSwitch size='xs' approvalType={approvalType} desc={`Auto-approve ${approvalType}`} />
-									</div>
-								})}
-
-							</ErrorBoundary>
-
-							{/* Tool Lint Errors Switch */}
-							<ErrorBoundary>
-
-								<div className='flex items-center gap-x-2 my-2'>
-									<VoidSwitch
-										size='xs'
-										value={settingsState.globalSettings.includeToolLintErrors}
-										onChange={(newVal) => voidSettingsService.setGlobalSetting('includeToolLintErrors', newVal)}
-									/>
-									<span className='text-void-fg-3 text-xs pointer-events-none'>{settingsState.globalSettings.includeToolLintErrors ? 'Fix lint errors' : `Fix lint errors`}</span>
-								</div>
-							</ErrorBoundary>
-						</div>
+							>
+								{label}
+							</button>
+						))}
 					</div>
+				</aside>
+
+				{/* ───────────── MAIN PANE ───────────── */}
+				<main className="flex-1 overflow-y-auto p-6 select-none">
 
 
 
-					<div className='w-full'>
-						<h4 className={`text-base`}>Editor</h4>
-						<div className='text-sm italic text-void-fg-3 mt-1'>{`Settings that control the visibility of Void suggestions in the code editor.`}</div>
+					<div className='max-w-3xl'>
 
-						<div className='my-2'>
-							{/* Auto Accept Switch */}
+						<h1 className='text-2xl w-full'>{`Void's Settings`}</h1>
+
+						<div className='w-full h-[1px] my-2' />
+
+						{/* Models section (formerly FeaturesTab) */}
+						<ErrorBoundary>
+							<RedoOnboardingButton />
+						</ErrorBoundary>
+
+						<div className='w-full h-[1px] my-4' />
+
+						{/* Models section (formerly FeaturesTab) */}
+						<ErrorBoundary>
+							{show('models') && (
+								<>
+									<h2 className={`text-3xl mb-2`}>Models</h2>
+									<ModelDump />
+									<div className='w-full h-[1px] my-4' />
+									<AutoDetectLocalModelsToggle />
+									<RefreshableModels />
+								</>
+							)}
+						</ErrorBoundary>
+						{show('localProviders') && (
 							<ErrorBoundary>
-								<div className='flex items-center gap-x-2 my-2'>
-									<VoidSwitch
-										size='xs'
-										value={settingsState.globalSettings.showInlineSuggestions}
-										onChange={(newVal) => voidSettingsService.setGlobalSetting('showInlineSuggestions', newVal)}
-									/>
-									<span className='text-void-fg-3 text-xs pointer-events-none'>{settingsState.globalSettings.showInlineSuggestions ? 'Show suggestions on select' : 'Show suggestions on select'}</span>
-								</div>
+								<>
+
+									<h2 className={`text-3xl mb-2 mt-12`}>Local Providers</h2>
+									<h3 className={`text-void-fg-3 mb-2`}>{`Void can access any model that you host locally. We automatically detect your local models by default.`}</h3>
+
+									<div className='opacity-80 mb-4'>
+										<OllamaSetupInstructions sayWeAutoDetect={true} />
+									</div>
+
+
+									<VoidProviderSettings providerNames={localProviderNames} />
+								</>
 							</ErrorBoundary>
-						</div>
-					</div>
-				</div>
-				    </>
-  </ErrorBoundary>
-)}
+						)}
+						{show('providers') && (
+							<ErrorBoundary>
+								<>
+									<h2 className={`text-3xl mb-2 mt-12`}>Providers</h2>
+									<h3 className={`text-void-fg-3 mb-2`}>{`Void can access models from Anthropic, OpenAI, OpenRouter, and more.`}</h3>
+
+									<VoidProviderSettings providerNames={nonlocalProviderNames} />
+								</>
+							</ErrorBoundary>
+						)}
 
 
-{show('general') && (
-  <>
+						{show('featureOptions') && (
+							<ErrorBoundary>
+								<>
+									<h2 className={`text-3xl mt-12`}>Feature Options</h2>
 
-				{/* General section (formerly GeneralTab) */}
-				<div className='mt-12'>
-					<ErrorBoundary>
-						<h2 className='text-3xl mb-2 mt-12'>One-Click Switch</h2>
-						<h4 className='text-void-fg-3 mb-4'>{`Transfer your editor settings into Void.`}</h4>
+									<div className='flex flex-col gap-y-8 my-4'>
+										<ErrorBoundary>
+											{/* FIM */}
+											<div>
+												<h4 className={`text-base`}>{displayInfoOfFeatureName('Autocomplete')}</h4>
+												<div className='text-sm italic text-void-fg-3 mt-1'>
+													<span>
+														Experimental.{' '}
+													</span>
+													<span
+														className='hover:brightness-110'
+														data-tooltip-id='void-tooltip'
+														data-tooltip-content='We recommend using the largest qwen2.5-coder model you can with Ollama (try qwen2.5-coder:3b).'
+														data-tooltip-class-name='void-max-w-[20px]'
+													>
+														Only works with FIM models.*
+													</span>
+												</div>
 
-						<div className='flex flex-col gap-2'>
-							<OneClickSwitchButton className='w-48' fromEditor="VS Code" />
-							<OneClickSwitchButton className='w-48' fromEditor="Cursor" />
-							<OneClickSwitchButton className='w-48' fromEditor="Windsurf" />
-						</div>
-					</ErrorBoundary>
-				</div>
+												<div className='my-2'>
+													{/* Enable Switch */}
+													<ErrorBoundary>
+														<div className='flex items-center gap-x-2 my-2'>
+															<VoidSwitch
+																size='xs'
+																value={settingsState.globalSettings.enableAutocomplete}
+																onChange={(newVal) => voidSettingsService.setGlobalSetting('enableAutocomplete', newVal)}
+															/>
+															<span className='text-void-fg-3 text-xs pointer-events-none'>{settingsState.globalSettings.enableAutocomplete ? 'Enabled' : 'Disabled'}</span>
+														</div>
+													</ErrorBoundary>
 
-				{/* Import/Export section, as its own block right after One-Click Switch */}
-				<div className='mt-12'>
-					<h2 className='text-3xl mb-2'>Import/Export</h2>
-					<h4 className='text-void-fg-3 mb-4'>{`Transfer Void's settings and chats in and out of Void.`}</h4>
-					<div className='flex flex-col gap-8'>
-						{/* Settings Subcategory */}
-						<div className='flex flex-col gap-2 max-w-48 w-full'>
-							<input key={2 * s} ref={fileInputSettingsRef} type='file' accept='.json' className='hidden' onChange={handleUpload('Settings')} />
-							<VoidButtonBgDarken className='px-4 py-1 w-full' onClick={() => { fileInputSettingsRef.current?.click() }}>
-								Import Settings
-							</VoidButtonBgDarken>
-							<VoidButtonBgDarken className='px-4 py-1 w-full' onClick={() => onDownload('Settings')}>
-								Export Settings
-							</VoidButtonBgDarken>
-							<ConfirmButton className='px-4 py-1 w-full' onConfirm={() => { voidSettingsService.resetState(); }}>
-								Reset Settings
-							</ConfirmButton>
-						</div>
-						{/* Chats Subcategory */}
-						<div className='flex flex-col gap-2 w-full max-w-48'>
-							<input key={2 * s + 1} ref={fileInputChatsRef} type='file' accept='.json' className='hidden' onChange={handleUpload('Chats')} />
-							<VoidButtonBgDarken className='px-4 py-1 w-full' onClick={() => { fileInputChatsRef.current?.click() }}>
-								Import Chats
-							</VoidButtonBgDarken>
-							<VoidButtonBgDarken className='px-4 py-1 w-full' onClick={() => onDownload('Chats')}>
-								Export Chats
-							</VoidButtonBgDarken>
-							<ConfirmButton className='px-4 py-1 w-full' onConfirm={() => { chatThreadsService.resetState(); }}>
-								Reset Chats
-							</ConfirmButton>
-						</div>
-					</div>
-				</div>
+													{/* Model Dropdown */}
+													<ErrorBoundary>
+														<div className={`my-2 ${!settingsState.globalSettings.enableAutocomplete ? 'hidden' : ''}`}>
+															<ModelDropdown featureName={'Autocomplete'} className='text-xs text-void-fg-3 bg-void-bg-1 border border-void-border-1 rounded p-0.5 px-1' />
+														</div>
+													</ErrorBoundary>
 
+												</div>
 
+											</div>
+										</ErrorBoundary>
 
-				<div className='mt-12'>
+										{/* Apply */}
+										<ErrorBoundary>
 
-					<h2 className={`text-3xl mb-2`}>Built-in Settings</h2>
-					<h4 className={`text-void-fg-3 mb-4`}>{`IDE settings, keyboard settings, and theme customization.`}</h4>
+											<div className='w-full'>
+												<h4 className={`text-base`}>{displayInfoOfFeatureName('Apply')}</h4>
+												<div className='text-sm italic text-void-fg-3 mt-1'>Settings that control the behavior of the Apply button.</div>
 
-					<ErrorBoundary>
-						<div className='flex flex-col gap-2 justify-center max-w-48 w-full'>
-							<VoidButtonBgDarken className='px-4 py-1' onClick={() => { commandService.executeCommand('workbench.action.openSettings') }}>
-								General Settings
-							</VoidButtonBgDarken>
-							<VoidButtonBgDarken className='px-4 py-1' onClick={() => { commandService.executeCommand('workbench.action.openGlobalKeybindings') }}>
-								Keyboard Settings
-							</VoidButtonBgDarken>
-							<VoidButtonBgDarken className='px-4 py-1' onClick={() => { commandService.executeCommand('workbench.action.selectTheme') }}>
-								Theme Settings
-							</VoidButtonBgDarken>
-							<VoidButtonBgDarken className='px-4 py-1' onClick={() => { nativeHostService.showItemInFolder(environmentService.logsHome.fsPath) }}>
-								Open Logs
-							</VoidButtonBgDarken>
-						</div>
-					</ErrorBoundary>
-				</div>
+												<div className='my-2'>
+													{/* Sync to Chat Switch */}
+													<div className='flex items-center gap-x-2 my-2'>
+														<VoidSwitch
+															size='xs'
+															value={settingsState.globalSettings.syncApplyToChat}
+															onChange={(newVal) => voidSettingsService.setGlobalSetting('syncApplyToChat', newVal)}
+														/>
+														<span className='text-void-fg-3 text-xs pointer-events-none'>{settingsState.globalSettings.syncApplyToChat ? 'Same as Chat model' : 'Different model'}</span>
+													</div>
+
+													{/* Model Dropdown */}
+													<div className={`my-2 ${settingsState.globalSettings.syncApplyToChat ? 'hidden' : ''}`}>
+														<ModelDropdown featureName={'Apply'} className='text-xs text-void-fg-3 bg-void-bg-1 border border-void-border-1 rounded p-0.5 px-1' />
+													</div>
+												</div>
 
 
-				<div className='mt-12 max-w-[600px]'>
-					<h2 className={`text-3xl mb-2`}>AI Instructions</h2>
-					<h4 className={`text-void-fg-3 mb-4`}>
-						<ChatMarkdownRender inPTag={true} string={`
+												<div className='my-2'>
+													{/* Fast Apply Method Dropdown */}
+													<div className='flex items-center gap-x-2 my-2'>
+														<FastApplyMethodDropdown />
+													</div>
+												</div>
+
+											</div>
+										</ErrorBoundary>
+
+
+
+
+										{/* Tools Section */}
+										<div>
+											<h4 className={`text-base`}>Tools</h4>
+											<div className='text-sm italic text-void-fg-3 mt-1'>{`Tools are functions that LLMs can call. Some tools require user approval.`}</div>
+
+											<div className='my-2'>
+												{/* Auto Accept Switch */}
+												<ErrorBoundary>
+													{[...toolApprovalTypes].map((approvalType) => {
+														return <div key={approvalType} className="flex items-center gap-x-2 my-2">
+															<ToolApprovalTypeSwitch size='xs' approvalType={approvalType} desc={`Auto-approve ${approvalType}`} />
+														</div>
+													})}
+
+												</ErrorBoundary>
+
+												{/* Tool Lint Errors Switch */}
+												<ErrorBoundary>
+
+													<div className='flex items-center gap-x-2 my-2'>
+														<VoidSwitch
+															size='xs'
+															value={settingsState.globalSettings.includeToolLintErrors}
+															onChange={(newVal) => voidSettingsService.setGlobalSetting('includeToolLintErrors', newVal)}
+														/>
+														<span className='text-void-fg-3 text-xs pointer-events-none'>{settingsState.globalSettings.includeToolLintErrors ? 'Fix lint errors' : `Fix lint errors`}</span>
+													</div>
+												</ErrorBoundary>
+											</div>
+										</div>
+
+
+
+										<div className='w-full'>
+											<h4 className={`text-base`}>Editor</h4>
+											<div className='text-sm italic text-void-fg-3 mt-1'>{`Settings that control the visibility of Void suggestions in the code editor.`}</div>
+
+											<div className='my-2'>
+												{/* Auto Accept Switch */}
+												<ErrorBoundary>
+													<div className='flex items-center gap-x-2 my-2'>
+														<VoidSwitch
+															size='xs'
+															value={settingsState.globalSettings.showInlineSuggestions}
+															onChange={(newVal) => voidSettingsService.setGlobalSetting('showInlineSuggestions', newVal)}
+														/>
+														<span className='text-void-fg-3 text-xs pointer-events-none'>{settingsState.globalSettings.showInlineSuggestions ? 'Show suggestions on select' : 'Show suggestions on select'}</span>
+													</div>
+												</ErrorBoundary>
+											</div>
+										</div>
+									</div>
+								</>
+							</ErrorBoundary>
+						)}
+
+
+						{show('general') && (
+							<>
+
+								{/* General section (formerly GeneralTab) */}
+								<div className='mt-12'>
+									<ErrorBoundary>
+										<h2 className='text-3xl mb-2 mt-12'>One-Click Switch</h2>
+										<h4 className='text-void-fg-3 mb-4'>{`Transfer your editor settings into Void.`}</h4>
+
+										<div className='flex flex-col gap-2'>
+											<OneClickSwitchButton className='w-48' fromEditor="VS Code" />
+											<OneClickSwitchButton className='w-48' fromEditor="Cursor" />
+											<OneClickSwitchButton className='w-48' fromEditor="Windsurf" />
+										</div>
+									</ErrorBoundary>
+								</div>
+
+								{/* Import/Export section, as its own block right after One-Click Switch */}
+								<div className='mt-12'>
+									<h2 className='text-3xl mb-2'>Import/Export</h2>
+									<h4 className='text-void-fg-3 mb-4'>{`Transfer Void's settings and chats in and out of Void.`}</h4>
+									<div className='flex flex-col gap-8'>
+										{/* Settings Subcategory */}
+										<div className='flex flex-col gap-2 max-w-48 w-full'>
+											<input key={2 * s} ref={fileInputSettingsRef} type='file' accept='.json' className='hidden' onChange={handleUpload('Settings')} />
+											<VoidButtonBgDarken className='px-4 py-1 w-full' onClick={() => { fileInputSettingsRef.current?.click() }}>
+												Import Settings
+											</VoidButtonBgDarken>
+											<VoidButtonBgDarken className='px-4 py-1 w-full' onClick={() => onDownload('Settings')}>
+												Export Settings
+											</VoidButtonBgDarken>
+											<ConfirmButton className='px-4 py-1 w-full' onConfirm={() => { voidSettingsService.resetState(); }}>
+												Reset Settings
+											</ConfirmButton>
+										</div>
+										{/* Chats Subcategory */}
+										<div className='flex flex-col gap-2 w-full max-w-48'>
+											<input key={2 * s + 1} ref={fileInputChatsRef} type='file' accept='.json' className='hidden' onChange={handleUpload('Chats')} />
+											<VoidButtonBgDarken className='px-4 py-1 w-full' onClick={() => { fileInputChatsRef.current?.click() }}>
+												Import Chats
+											</VoidButtonBgDarken>
+											<VoidButtonBgDarken className='px-4 py-1 w-full' onClick={() => onDownload('Chats')}>
+												Export Chats
+											</VoidButtonBgDarken>
+											<ConfirmButton className='px-4 py-1 w-full' onConfirm={() => { chatThreadsService.resetState(); }}>
+												Reset Chats
+											</ConfirmButton>
+										</div>
+									</div>
+								</div>
+
+
+
+								<div className='mt-12'>
+
+									<h2 className={`text-3xl mb-2`}>Built-in Settings</h2>
+									<h4 className={`text-void-fg-3 mb-4`}>{`IDE settings, keyboard settings, and theme customization.`}</h4>
+
+									<ErrorBoundary>
+										<div className='flex flex-col gap-2 justify-center max-w-48 w-full'>
+											<VoidButtonBgDarken className='px-4 py-1' onClick={() => { commandService.executeCommand('workbench.action.openSettings') }}>
+												General Settings
+											</VoidButtonBgDarken>
+											<VoidButtonBgDarken className='px-4 py-1' onClick={() => { commandService.executeCommand('workbench.action.openGlobalKeybindings') }}>
+												Keyboard Settings
+											</VoidButtonBgDarken>
+											<VoidButtonBgDarken className='px-4 py-1' onClick={() => { commandService.executeCommand('workbench.action.selectTheme') }}>
+												Theme Settings
+											</VoidButtonBgDarken>
+											<VoidButtonBgDarken className='px-4 py-1' onClick={() => { nativeHostService.showItemInFolder(environmentService.logsHome.fsPath) }}>
+												Open Logs
+											</VoidButtonBgDarken>
+										</div>
+									</ErrorBoundary>
+								</div>
+
+
+								<div className='mt-12 max-w-[600px]'>
+									<h2 className={`text-3xl mb-2`}>AI Instructions</h2>
+									<h4 className={`text-void-fg-3 mb-4`}>
+										<ChatMarkdownRender inPTag={true} string={`
 System instructions to include with all AI requests.
 Alternatively, place a \`.voidrules\` file in the root of your workspace.
 								`} chatMessageLocation={undefined} />
-					</h4>
-					<ErrorBoundary>
-						<AIInstructionsBox />
-					</ErrorBoundary>
-			</div>
-  </>
-)}
+									</h4>
+									<ErrorBoundary>
+										<AIInstructionsBox />
+									</ErrorBoundary>
+								</div>
+							</>
+						)}
 
-  </div>
-</main>
-</div>
-</div>
-);
+					</div>
+				</main>
+			</div>
+		</div>
+	);
 }

--- a/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
@@ -27,6 +27,7 @@ type Tab =
 	| 'localProviders'
 	| 'providers'
 	| 'featureOptions'
+	| 'mcp'
 	| 'general'
 	| 'all';
 
@@ -1036,6 +1037,7 @@ export const Settings = () => {
 		{ tab: 'localProviders', label: 'Local Providers' },
 		{ tab: 'providers', label: 'Other Providers' },
 		{ tab: 'featureOptions', label: 'Feature Options' },
+		{ tab: 'mcp', label: 'MCP' },
 		{ tab: 'general', label: 'General' },
 		{ tab: 'all', label: 'All Settings' },
 	];
@@ -1343,6 +1345,27 @@ export const Settings = () => {
 								</ErrorBoundary>
 							</div>
 
+							{/* MCP section */}
+							<div className={shouldShowTab('mcp') ? `` : 'hidden'}>
+								<ErrorBoundary>
+									<h2 className='text-3xl mb-2'>MCP</h2>
+									<h4 className={`text-void-fg-3 mb-4`}>
+										<ChatMarkdownRender inPTag={true} string={`
+Use Model Context Protocol to provide Agent mode with more tools.
+							`} chatMessageLocation={undefined} />
+									</h4>
+									<div className='my-2'>
+										<VoidButtonBgDarken className='px-4 py-1 w-full max-w-48' onClick={async () => { await mcpService.revealMCPConfigFile() }}>
+											Add MCP Server
+										</VoidButtonBgDarken>
+									</div>
+
+									<ErrorBoundary>
+										<MCPServersList />
+									</ErrorBoundary>
+								</ErrorBoundary>
+							</div>
+
 							{/* General section */}
 							<div className={`${shouldShowTab('general') ? `` : 'hidden'} flex flex-col gap-12`}>
 								{/* One-Click Switch section */}
@@ -1397,7 +1420,6 @@ export const Settings = () => {
 
 								{/* Built-in Settings section */}
 								<div>
-
 									<h2 className={`text-3xl mb-2`}>Built-in Settings</h2>
 									<h4 className={`text-void-fg-3 mb-4`}>{`IDE settings, keyboard settings, and theme customization.`}</h4>
 
@@ -1432,8 +1454,29 @@ Alternatively, place a \`.voidrules\` file in the root of your workspace.
 									<ErrorBoundary>
 										<AIInstructionsBox />
 									</ErrorBoundary>
+									{/* --- Disable System Message Toggle --- */}
+									<div className='my-4'>
+										<ErrorBoundary>
+											<div className='flex items-center gap-x-2'>
+												<VoidSwitch
+													size='xs'
+													value={!!settingsState.globalSettings.disableSystemMessage}
+													onChange={(newValue) => {
+														voidSettingsService.setGlobalSetting('disableSystemMessage', newValue);
+													}}
+												/>
+												<span className='text-void-fg-3 text-xs pointer-events-none'>
+													{'Disable system message'}
+												</span>
+											</div>
+										</ErrorBoundary>
+										<div className='text-void-fg-3 text-xs mt-1'>
+											{`When disabled, Void will not include anything in the system message except for content you specified above.`}
+										</div>
+									</div>
 								</div>
 							</div>
+
 						</div>
 
 					</div>

--- a/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
@@ -19,6 +19,16 @@ import { ToolApprovalType, toolApprovalTypes } from '../../../../common/toolsSer
 import Severity from '../../../../../../../base/common/severity.js'
 import { getModelCapabilities, ModelOverrides } from '../../../../common/modelCapabilities.js';
 import { TransferEditorType, TransferFilesInfo } from '../../../extensionTransferTypes.js';
+// ─────────────────────────────────────────────
+//  Sidebar navigation helpers
+// ─────────────────────────────────────────────
+type SectionKey =
+  | 'models'
+  | 'localProviders'
+  | 'providers'
+  | 'featureOptions'
+  | 'general'
+  | 'all';
 
 const ButtonLeftTextRightOption = ({ text, leftButton }: { text: string, leftButton?: React.ReactNode }) => {
 
@@ -906,6 +916,19 @@ export const OneClickSwitchButton = ({ fromEditor = 'VS Code', className = '' }:
 
 export const Settings = () => {
 	const isDark = useIsDark()
+  // ─── sidebar nav ──────────────────────────
+  const [selectedSection, setSelectedSection] =
+    useState<SectionKey>('models');
+
+  const navItems: { key: SectionKey; label: string }[] = [
+    { key: 'models',         label: 'Models' },
+    { key: 'localProviders', label: 'Local Providers' },
+    { key: 'providers',      label: 'Providers' },
+    { key: 'featureOptions', label: 'Feature Options' },
+    { key: 'general',        label: 'General' },
+    { key: 'all',            label: 'All Settings' },
+  ];
+    const show = (key: SectionKey) => selectedSection === 'all' || selectedSection === key;
 	const accessor = useAccessor()
 	const commandService = accessor.get('ICommandService')
 	const environmentService = accessor.get('IEnvironmentService')
@@ -979,10 +1002,44 @@ export const Settings = () => {
 	}
 
 
-	return <div className={`@@void-scope ${isDark ? 'dark' : ''}`} style={{ height: '100%', width: '100%' }}>
-		<div className='overflow-y-auto w-full h-full px-10 py-10 select-none'>
+	return (
+  <div className={`@@void-scope ${isDark ? 'dark' : ''}`} style={{ height: '100%', width: '100%' }}>
+    <div className="flex flex-col md:flex-row w-full h-[80vh] gap-6 max-w-[900px] mx-auto">
+      {/* ──────────────  SIDEBAR  ────────────── */}
 
-			<div className='max-w-xl mx-auto'>
+<aside className="md:w-1/4 w-full p-6 shrink-0 overflow-y-auto">
+  {/* vertical tab list */}
+  <div className="flex flex-col gap-2">
+    {navItems.map(({ key, label }) => (
+      <button
+        key={key}
+               onClick={() => {
+          if (key === 'all') {
+          setSelectedSection('all');
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            setSelectedSection(key);
+          }
+        }}
+        className={`
+          py-2 px-4 rounded-md text-left transition-all duration-200
+          ${selectedSection === key
+            ? 'bg-[#0e70c0]/80 text-white font-medium shadow-sm'
+            : 'bg-void-bg-2 hover:bg-void-bg-2/80 text-void-fg-1'}
+        `}
+      >
+        {label}
+      </button>
+    ))}
+  </div>
+</aside>
+
+      {/* ───────────── MAIN PANE ───────────── */}
+      <main className="flex-1 overflow-y-auto p-6 select-none">
+
+
+
+			<div className='max-w-3xl'>
 
 				<h1 className='text-2xl w-full'>{`Void's Settings`}</h1>
 
@@ -997,13 +1054,19 @@ export const Settings = () => {
 
 				{/* Models section (formerly FeaturesTab) */}
 				<ErrorBoundary>
+{show('models') && (
+<>
 					<h2 className={`text-3xl mb-2`}>Models</h2>
 					<ModelDump />
 					<div className='w-full h-[1px] my-4' />
 					<AutoDetectLocalModelsToggle />
 					<RefreshableModels />
+    </>
+  )}
 				</ErrorBoundary>
-
+{show('localProviders') && (
+  <ErrorBoundary>
+    <>
 
 				<h2 className={`text-3xl mb-2 mt-12`}>Local Providers</h2>
 				<h3 className={`text-void-fg-3 mb-2`}>{`Void can access any model that you host locally. We automatically detect your local models by default.`}</h3>
@@ -1012,18 +1075,26 @@ export const Settings = () => {
 					<OllamaSetupInstructions sayWeAutoDetect={true} />
 				</div>
 
-				<ErrorBoundary>
-					<VoidProviderSettings providerNames={localProviderNames} />
-				</ErrorBoundary>
 
+					<VoidProviderSettings providerNames={localProviderNames} />
+				    </>
+  </ErrorBoundary>
+)}
+{show('providers') && (
+  <ErrorBoundary>
+    <>
 				<h2 className={`text-3xl mb-2 mt-12`}>Providers</h2>
 				<h3 className={`text-void-fg-3 mb-2`}>{`Void can access models from Anthropic, OpenAI, OpenRouter, and more.`}</h3>
-				<ErrorBoundary>
+
 					<VoidProviderSettings providerNames={nonlocalProviderNames} />
-				</ErrorBoundary>
+				    </>
+  </ErrorBoundary>
+)}
 
 
-
+{show('featureOptions') && (
+  <ErrorBoundary>
+    <>
 				<h2 className={`text-3xl mt-12`}>Feature Options</h2>
 
 				<div className='flex flex-col gap-y-8 my-4'>
@@ -1108,7 +1179,6 @@ export const Settings = () => {
 
 
 
-
 					{/* Tools Section */}
 					<div>
 						<h4 className={`text-base`}>Tools</h4>
@@ -1161,7 +1231,13 @@ export const Settings = () => {
 						</div>
 					</div>
 				</div>
+				    </>
+  </ErrorBoundary>
+)}
 
+
+{show('general') && (
+  <>
 
 				{/* General section (formerly GeneralTab) */}
 				<div className='mt-12'>
@@ -1248,9 +1324,13 @@ Alternatively, place a \`.voidrules\` file in the root of your workspace.
 					<ErrorBoundary>
 						<AIInstructionsBox />
 					</ErrorBoundary>
-				</div>
 			</div>
-		</div>
-	</div>
-}
+  </>
+)}
 
+  </div>
+</main>
+</div>
+</div>
+);
+}

--- a/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
@@ -22,7 +22,7 @@ import { TransferEditorType, TransferFilesInfo } from '../../../extensionTransfe
 // ─────────────────────────────────────────────
 //  Sidebar navigation helpers
 // ─────────────────────────────────────────────
-type SectionKey =
+type Tab =
 	| 'models'
 	| 'localProviders'
 	| 'providers'
@@ -912,17 +912,17 @@ export const Settings = () => {
 	const isDark = useIsDark()
 	// ─── sidebar nav ──────────────────────────
 	const [selectedSection, setSelectedSection] =
-		useState<SectionKey>('models');
+		useState<Tab>('models');
 
-	const navItems: { key: SectionKey; label: string }[] = [
-		{ key: 'models', label: 'Models' },
-		{ key: 'localProviders', label: 'Local Providers' },
-		{ key: 'providers', label: 'Providers' },
-		{ key: 'featureOptions', label: 'Feature Options' },
-		{ key: 'general', label: 'General' },
-		{ key: 'all', label: 'All Settings' },
+	const navItems: { tab: Tab; label: string }[] = [
+		{ tab: 'models', label: 'Models' },
+		{ tab: 'localProviders', label: 'Local Providers' },
+		{ tab: 'providers', label: 'Other Providers' },
+		{ tab: 'featureOptions', label: 'Feature Options' },
+		{ tab: 'general', label: 'General' },
+		{ tab: 'all', label: 'All Settings' },
 	];
-	const show = (key: SectionKey) => selectedSection === 'all' || selectedSection === key;
+	const shouldShowTab = (tab: Tab) => selectedSection === 'all' || selectedSection === tab;
 	const accessor = useAccessor()
 	const commandService = accessor.get('ICommandService')
 	const environmentService = accessor.get('IEnvironmentService')
@@ -997,27 +997,27 @@ export const Settings = () => {
 
 
 	return (
-		<div className={`@@void-scope ${isDark ? 'dark' : ''}`} style={{ height: '100%', width: '100%' }}>
-			<div className="flex flex-col md:flex-row w-full h-[80vh] gap-6 max-w-[900px] mx-auto">
+		<div className={`@@void-scope ${isDark ? 'dark' : ''}`} style={{ height: '100%', width: '100%', overflow: 'auto' }}>
+			<div className="flex flex-col md:flex-row w-full gap-6 max-w-[900px] mx-auto mb-32" style={{ minHeight: '80vh' }}>
 				{/* ──────────────  SIDEBAR  ────────────── */}
 
-				<aside className="md:w-1/4 w-full p-6 shrink-0 overflow-y-auto">
+				<aside className="md:w-1/4 w-full p-6 shrink-0">
 					{/* vertical tab list */}
-					<div className="flex flex-col gap-2">
-						{navItems.map(({ key, label }) => (
+					<div className="flex flex-col gap-2 mt-12">
+						{navItems.map(({ tab, label }) => (
 							<button
-								key={key}
+								key={tab}
 								onClick={() => {
-									if (key === 'all') {
+									if (tab === 'all') {
 										setSelectedSection('all');
 										window.scrollTo({ top: 0, behavior: 'smooth' });
 									} else {
-										setSelectedSection(key);
+										setSelectedSection(tab);
 									}
 								}}
 								className={`
           py-2 px-4 rounded-md text-left transition-all duration-200
-          ${selectedSection === key
+          ${selectedSection === tab
 										? 'bg-[#0e70c0]/80 text-white font-medium shadow-sm'
 										: 'bg-void-bg-2 hover:bg-void-bg-2/80 text-void-fg-1'}
         `}
@@ -1029,7 +1029,7 @@ export const Settings = () => {
 				</aside>
 
 				{/* ───────────── MAIN PANE ───────────── */}
-				<main className="flex-1 overflow-y-auto p-6 select-none">
+				<main className="flex-1 p-6 select-none">
 
 
 
@@ -1046,50 +1046,47 @@ export const Settings = () => {
 
 						<div className='w-full h-[1px] my-4' />
 
-						{/* Models section (formerly FeaturesTab) */}
-						<ErrorBoundary>
-							{show('models') && (
-								<>
+						{/* All sections in flex container with gap-12 */}
+						<div className='flex flex-col gap-12'>
+							{/* Models section (formerly FeaturesTab) */}
+							<div className={shouldShowTab('models') ? `` : 'hidden'}>
+								<ErrorBoundary>
 									<h2 className={`text-3xl mb-2`}>Models</h2>
 									<ModelDump />
 									<div className='w-full h-[1px] my-4' />
 									<AutoDetectLocalModelsToggle />
 									<RefreshableModels />
-								</>
-							)}
-						</ErrorBoundary>
-						{show('localProviders') && (
-							<ErrorBoundary>
-								<>
+								</ErrorBoundary>
+							</div>
 
-									<h2 className={`text-3xl mb-2 mt-12`}>Local Providers</h2>
+							{/* Local Providers section */}
+							<div className={shouldShowTab('localProviders') ? `` : 'hidden'}>
+								<ErrorBoundary>
+									<h2 className={`text-3xl mb-2`}>Local Providers</h2>
 									<h3 className={`text-void-fg-3 mb-2`}>{`Void can access any model that you host locally. We automatically detect your local models by default.`}</h3>
 
 									<div className='opacity-80 mb-4'>
 										<OllamaSetupInstructions sayWeAutoDetect={true} />
 									</div>
 
-
 									<VoidProviderSettings providerNames={localProviderNames} />
-								</>
-							</ErrorBoundary>
-						)}
-						{show('providers') && (
-							<ErrorBoundary>
-								<>
-									<h2 className={`text-3xl mb-2 mt-12`}>Providers</h2>
+								</ErrorBoundary>
+							</div>
+
+							{/* Other Providers section */}
+							<div className={shouldShowTab('providers') ? `` : 'hidden'}>
+								<ErrorBoundary>
+									<h2 className={`text-3xl mb-2`}>Other Providers</h2>
 									<h3 className={`text-void-fg-3 mb-2`}>{`Void can access models from Anthropic, OpenAI, OpenRouter, and more.`}</h3>
 
 									<VoidProviderSettings providerNames={nonlocalProviderNames} />
-								</>
-							</ErrorBoundary>
-						)}
+								</ErrorBoundary>
+							</div>
 
-
-						{show('featureOptions') && (
-							<ErrorBoundary>
-								<>
-									<h2 className={`text-3xl mt-12`}>Feature Options</h2>
+							{/* Feature Options section */}
+							<div className={shouldShowTab('featureOptions') ? `` : 'hidden'}>
+								<ErrorBoundary>
+									<h2 className={`text-3xl mb-2`}>Feature Options</h2>
 
 									<div className='flex flex-col gap-y-8 my-4'>
 										<ErrorBoundary>
@@ -1225,18 +1222,15 @@ export const Settings = () => {
 											</div>
 										</div>
 									</div>
-								</>
-							</ErrorBoundary>
-						)}
+								</ErrorBoundary>
+							</div>
 
-
-						{show('general') && (
-							<>
-
-								{/* General section (formerly GeneralTab) */}
-								<div className='mt-12'>
+							{/* General section */}
+							<div className={`${shouldShowTab('general') ? `` : 'hidden'} flex flex-col gap-12`}>
+								{/* One-Click Switch section */}
+								<div>
 									<ErrorBoundary>
-										<h2 className='text-3xl mb-2 mt-12'>One-Click Switch</h2>
+										<h2 className='text-3xl mb-2'>One-Click Switch</h2>
 										<h4 className='text-void-fg-3 mb-4'>{`Transfer your editor settings into Void.`}</h4>
 
 										<div className='flex flex-col gap-2'>
@@ -1247,8 +1241,8 @@ export const Settings = () => {
 									</ErrorBoundary>
 								</div>
 
-								{/* Import/Export section, as its own block right after One-Click Switch */}
-								<div className='mt-12'>
+								{/* Import/Export section */}
+								<div>
 									<h2 className='text-3xl mb-2'>Import/Export</h2>
 									<h4 className='text-void-fg-3 mb-4'>{`Transfer Void's settings and chats in and out of Void.`}</h4>
 									<div className='flex flex-col gap-8'>
@@ -1283,7 +1277,8 @@ export const Settings = () => {
 
 
 
-								<div className='mt-12'>
+								{/* Built-in Settings section */}
+								<div>
 
 									<h2 className={`text-3xl mb-2`}>Built-in Settings</h2>
 									<h4 className={`text-void-fg-3 mb-4`}>{`IDE settings, keyboard settings, and theme customization.`}</h4>
@@ -1307,7 +1302,8 @@ export const Settings = () => {
 								</div>
 
 
-								<div className='mt-12 max-w-[600px]'>
+								{/* AI Instructions section */}
+								<div className='max-w-[600px]'>
 									<h2 className={`text-3xl mb-2`}>AI Instructions</h2>
 									<h4 className={`text-void-fg-3 mb-4`}>
 										<ChatMarkdownRender inPTag={true} string={`
@@ -1319,8 +1315,8 @@ Alternatively, place a \`.voidrules\` file in the root of your workspace.
 										<AIInstructionsBox />
 									</ErrorBoundary>
 								</div>
-							</>
-						)}
+							</div>
+						</div>
 
 					</div>
 				</main>

--- a/src/vs/workbench/contrib/void/common/toolsServiceTypes.ts
+++ b/src/vs/workbench/contrib/void/common/toolsServiceTypes.ts
@@ -18,7 +18,7 @@ export type ShallowDirectoryItem = {
 }
 
 
-export const approvalTypeOfBuiltinToolName: Partial<{ [T in BuiltinToolName]?: 'edits' | 'terminal' | 'mcp-tools' }> = {
+export const approvalTypeOfBuiltinToolName: Partial<{ [T in BuiltinToolName]?: 'edits' | 'terminal' | 'MCP tools' }> = {
 	'create_file_or_folder': 'edits',
 	'delete_file_or_folder': 'edits',
 	'rewrite_file': 'edits',
@@ -35,7 +35,7 @@ export type ToolApprovalType = NonNullable<(typeof approvalTypeOfBuiltinToolName
 
 export const toolApprovalTypes = new Set<ToolApprovalType>([
 	...Object.values(approvalTypeOfBuiltinToolName),
-	'mcp-tools',
+	'MCP tools',
 ])
 
 


### PR DESCRIPTION
PR for #592 

Tabs tested well and people asked for a “show-everything” view.

as such now, new users can skim every setting in one go, while power users hop straight to the block they need (All Settings).

we’re generally re-using that tab layout from the onboarding flow, so the navigation pattern is consistent across the product.

https://github.com/user-attachments/assets/625a7fba-4b39-46be-9b64-ef3116928a4d

