### PR TITLE
feat: Add Toggle to Disable AI System Message Context

### DIFF
--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -170,7 +170,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 			cols,
 			rows,
 			useConpty,
-			...(useConptyDll ? { useConptyDll } : {}) as IPtyForkOptions,
+			useConptyDll,
 			// This option will force conpty to not redraw the whole viewport on launch
 			conptyInheritCursor: useConpty && !!shellLaunchConfig.initialText
 		};
@@ -392,7 +392,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 			return;
 		}
 		// Don't throttle when using conpty.dll as it seems to have been fixed in later versions
-		if ((this._ptyOptions as any).useConptyDll) {
+		if (this._ptyOptions.useConptyDll) {
 			return;
 		}
 		// Use a loop to ensure multiple calls in a single interval space out

--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -170,7 +170,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 			cols,
 			rows,
 			useConpty,
-			useConptyDll,
+			...(useConptyDll ? { useConptyDll } : {}) as IPtyForkOptions,
 			// This option will force conpty to not redraw the whole viewport on launch
 			conptyInheritCursor: useConpty && !!shellLaunchConfig.initialText
 		};
@@ -392,7 +392,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 			return;
 		}
 		// Don't throttle when using conpty.dll as it seems to have been fixed in later versions
-		if (this._ptyOptions.useConptyDll) {
+		if ((this._ptyOptions as any).useConptyDll) {
 			return;
 		}
 		// Use a loop to ensure multiple calls in a single interval space out

--- a/src/vs/workbench/contrib/void/browser/convertToLLMMessageService.ts
+++ b/src/vs/workbench/contrib/void/browser/convertToLLMMessageService.ts
@@ -667,7 +667,7 @@ class ConvertToLLMMessageService extends Disposable implements IConvertToLLMMess
 		})
 		return { messages, separateSystemMessage };
 	}
-	prepareLLMChatMessages: IConvertToLLMMessageService['prepareLLMChatMessages'] = async ({ chatMessages, chatMode, modelSelection, }) => {
+	prepareLLMChatMessages: IConvertToLLMMessageService['prepareLLMChatMessages'] = async ({ chatMessages, chatMode, modelSelection }) => {
 		if (modelSelection === null) return { messages: [], separateSystemMessage: undefined }
 
 		const { overridesOfModel } = this.voidSettingsService.state

--- a/src/vs/workbench/contrib/void/browser/convertToLLMMessageService.ts
+++ b/src/vs/workbench/contrib/void/browser/convertToLLMMessageService.ts
@@ -520,7 +520,7 @@ const prepareMessages = (params: {
 export interface IConvertToLLMMessageService {
 	readonly _serviceBrand: undefined;
 	prepareLLMSimpleMessages: (opts: { simpleMessages: SimpleLLMMessage[], systemMessage: string, modelSelection: ModelSelection | null, featureName: FeatureName }) => { messages: LLMChatMessage[], separateSystemMessage: string | undefined }
-	prepareLLMChatMessages: (opts: { chatMessages: ChatMessage[], chatMode: ChatMode, modelSelection: ModelSelection | null, explicitlyDisableSystemMessage?: boolean, explicitlyProvideAiInstructions?: string, }) => Promise<{ messages: LLMChatMessage[], separateSystemMessage: string | undefined }>
+	prepareLLMChatMessages: (opts: { chatMessages: ChatMessage[], chatMode: ChatMode, modelSelection: ModelSelection | null }) => Promise<{ messages: LLMChatMessage[], separateSystemMessage: string | undefined }>
 	prepareFIMMessage(opts: { messages: LLMFIMMessage, }): { prefix: string, suffix: string, stopTokens: string[] }
 }
 
@@ -662,7 +662,7 @@ class ConvertToLLMMessageService extends Disposable implements IConvertToLLMMess
 		})
 		return { messages, separateSystemMessage };
 	}
-	prepareLLMChatMessages: IConvertToLLMMessageService['prepareLLMChatMessages'] = async ({ chatMessages, chatMode, modelSelection, explicitlyDisableSystemMessage, explicitlyProvideAiInstructions, }) => {
+	prepareLLMChatMessages: IConvertToLLMMessageService['prepareLLMChatMessages'] = async ({ chatMessages, chatMode, modelSelection, }) => {
 		if (modelSelection === null) return { messages: [], separateSystemMessage: undefined }
 
 		const { overridesOfModel } = this.voidSettingsService.state
@@ -679,9 +679,9 @@ class ConvertToLLMMessageService extends Disposable implements IConvertToLLMMess
 		const modelSelectionOptions = this.voidSettingsService.state.optionsOfModelSelection['Chat'][modelSelection.providerName]?.[modelSelection.modelName]
 
 		// Get combined AI instructions
-		const aiInstructions = explicitlyProvideAiInstructions || this._getCombinedAIInstructions();
+		const aiInstructions = this._getCombinedAIInstructions();
 		const globalDisableSystemMessageSetting = this.voidSettingsService.state.globalSettings.disableSystemMessage;
-		const finalSystemMessageForPrepareMessages = (explicitlyDisableSystemMessage || globalDisableSystemMessageSetting) ? undefined : systemMessageFromGenerator;
+		const finalSystemMessageForPrepareMessages = globalDisableSystemMessageSetting ? undefined : systemMessageFromGenerator;
 		const isReasoningEnabled = getIsReasoningEnabledState('Chat', providerName, modelName, modelSelectionOptions, overridesOfModel)
 		const reservedOutputTokenSpace = getReservedOutputTokenSpace(providerName, modelName, { isReasoningEnabled, overridesOfModel })
 		const llmMessages = this._chatMessagesToSimpleMessages(chatMessages)

--- a/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
@@ -5,6 +5,7 @@
 
 import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react'; // Added useRef import just in case it was missed, though likely already present
 import { ProviderName, SettingName, displayInfoOfSettingName, providerNames, VoidStatefulModelInfo, customSettingNamesOfProvider, RefreshableProviderName, refreshableProviderNames, displayInfoOfProviderName, nonlocalProviderNames, localProviderNames, GlobalSettingName, featureNames, displayInfoOfFeatureName, isProviderNameDisabled, FeatureName, hasDownloadButtonsOnModelsProviderNames, subTextMdOfProviderName } from '../../../../common/voidSettingsTypes.js'
+import { IVoidSettingsService, DISABLE_SYSTEM_MESSAGE_SETTING_ID } from '../../../../common/voidSettingsService.js';
 import ErrorBoundary from '../sidebar-tsx/ErrorBoundary.js'
 import { VoidButtonBgDarken, VoidCustomDropdownBox, VoidInputBox2, VoidSimpleInputBox, VoidSwitch } from '../util/inputs.js'
 import { useAccessor, useIsDark, useRefreshModelListener, useRefreshModelState, useSettingsState } from '../util/services.js'
@@ -1242,6 +1243,25 @@ Alternatively, place a \`.voidrules\` file in the root of your workspace.
 					<ErrorBoundary>
 						<AIInstructionsBox />
 					</ErrorBoundary>
+					{/* --- Disable System Message Toggle --- */}
+                    <div className='my-4'>
+                        <ErrorBoundary>
+						<div className='flex items-center gap-x-2'>
+                            <VoidSwitch
+                                size='xs'
+                                value={settingsState.globalSettings.disableSystemMessage}
+                                onChange={(newValue) => {
+                                    voidSettingsService.setGlobalSetting('disableSystemMessage', newValue);
+                                }}
+                            />
+                            <span className='text-void-fg-3 text-xs pointer-events-none'>
+                                {settingsState.globalSettings.disableSystemMessage ? 'Minimal system messages sent' : 'Full system messages sent'}
+                            </span>
+                        </div>
+						</ErrorBoundary>
+                        <div className='text-void-fg-3 text-xs mt-1'> When enabled, Void will send a minimal system message to the model to reduce token usage and improve model performance for certain tasks.
+                        </div>
+                    </div>
 				</div>
 			</div>
 		</div>

--- a/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
@@ -5,7 +5,6 @@
 
 import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react'; // Added useRef import just in case it was missed, though likely already present
 import { ProviderName, SettingName, displayInfoOfSettingName, providerNames, VoidStatefulModelInfo, customSettingNamesOfProvider, RefreshableProviderName, refreshableProviderNames, displayInfoOfProviderName, nonlocalProviderNames, localProviderNames, GlobalSettingName, featureNames, displayInfoOfFeatureName, isProviderNameDisabled, FeatureName, hasDownloadButtonsOnModelsProviderNames, subTextMdOfProviderName } from '../../../../common/voidSettingsTypes.js'
-import { IVoidSettingsService, DISABLE_SYSTEM_MESSAGE_SETTING_ID } from '../../../../common/voidSettingsService.js';
 import ErrorBoundary from '../sidebar-tsx/ErrorBoundary.js'
 import { VoidButtonBgDarken, VoidCustomDropdownBox, VoidInputBox2, VoidSimpleInputBox, VoidSwitch } from '../util/inputs.js'
 import { useAccessor, useIsDark, useRefreshModelListener, useRefreshModelState, useSettingsState } from '../util/services.js'

--- a/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
@@ -1258,7 +1258,8 @@ Alternatively, place a \`.voidrules\` file in the root of your workspace.
                             </span>
                         </div>
 						</ErrorBoundary>
-                        <div className='text-void-fg-3 text-xs mt-1'> When enabled, Void will send a minimal system message to the model to reduce token usage and improve model performance for certain tasks.
+                        <div className='text-void-fg-3 text-xs mt-1'>
+							{`When enabled, Void will not include anything in the system message except for content you specified in voidrules and AI Instructions.`}
                         </div>
                     </div>
 				</div>

--- a/src/vs/workbench/contrib/void/common/voidSettingsService.ts
+++ b/src/vs/workbench/contrib/void/common/voidSettingsService.ts
@@ -13,7 +13,8 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { IMetricsService } from './metricsService.js';
 import { defaultProviderSettings, getModelCapabilities, ModelOverrides } from './modelCapabilities.js';
 import { VOID_SETTINGS_STORAGE_KEY } from './storageKeys.js';
-import { defaultSettingsOfProvider, FeatureName, ProviderName, ModelSelectionOfFeature, SettingsOfProvider, SettingName, providerNames, ModelSelection, modelSelectionsEqual, featureNames, VoidStatefulModelInfo, GlobalSettings, GlobalSettingName, defaultGlobalSettings, ModelSelectionOptions, OptionsOfModelSelection, ChatMode, OverridesOfModel, defaultOverridesOfModel } from './voidSettingsTypes.js';
+import { defaultSettingsOfProvider, FeatureName, ProviderName, ModelSelectionOfFeature, SettingsOfProvider, SettingName, providerNames, ModelSelection, modelSelectionsEqual, featureNames, VoidStatefulModelInfo, GlobalSettings, GlobalSettingName, defaultGlobalSettings, ModelSelectionOptions, OptionsOfModelSelection, ChatMode, OverridesOfModel, defaultOverridesOfModel, } from './voidSettingsTypes.js';
+export const DISABLE_SYSTEM_MESSAGE_SETTING_ID = 'void.disableSystemMessage';
 
 
 // name is the name in the dropdown
@@ -272,6 +273,8 @@ class VoidSettingsService extends Disposable implements IVoidSettingsService {
 
 			// autoapprove is now an obj not a boolean (1.2.5)
 			if (typeof readS.globalSettings.autoApprove === 'boolean') readS.globalSettings.autoApprove = {}
+
+			if (readS.globalSettings.disableSystemMessage === undefined) readS.globalSettings.disableSystemMessage = false;
 		}
 		catch (e) {
 			readS = defaultState()

--- a/src/vs/workbench/contrib/void/common/voidSettingsService.ts
+++ b/src/vs/workbench/contrib/void/common/voidSettingsService.ts
@@ -14,7 +14,6 @@ import { IMetricsService } from './metricsService.js';
 import { defaultProviderSettings, getModelCapabilities, ModelOverrides } from './modelCapabilities.js';
 import { VOID_SETTINGS_STORAGE_KEY } from './storageKeys.js';
 import { defaultSettingsOfProvider, FeatureName, ProviderName, ModelSelectionOfFeature, SettingsOfProvider, SettingName, providerNames, ModelSelection, modelSelectionsEqual, featureNames, VoidStatefulModelInfo, GlobalSettings, GlobalSettingName, defaultGlobalSettings, ModelSelectionOptions, OptionsOfModelSelection, ChatMode, OverridesOfModel, defaultOverridesOfModel, } from './voidSettingsTypes.js';
-export const DISABLE_SYSTEM_MESSAGE_SETTING_ID = 'void.disableSystemMessage';
 
 
 // name is the name in the dropdown

--- a/src/vs/workbench/contrib/void/common/voidSettingsTypes.ts
+++ b/src/vs/workbench/contrib/void/common/voidSettingsTypes.ts
@@ -434,6 +434,7 @@ export type GlobalSettings = {
 	showInlineSuggestions: boolean;
 	includeToolLintErrors: boolean;
 	isOnboardingComplete: boolean;
+	disableSystemMessage: boolean;
 }
 
 export const defaultGlobalSettings: GlobalSettings = {
@@ -447,6 +448,7 @@ export const defaultGlobalSettings: GlobalSettings = {
 	showInlineSuggestions: true,
 	includeToolLintErrors: true,
 	isOnboardingComplete: false,
+	disableSystemMessage: false,
 }
 
 export type GlobalSettingName = keyof GlobalSettings


### PR DESCRIPTION
A toggle has been implemented within the settings, to allow users to easily enable or disable the inclusion of the built-in default context in AI requests and only use .voidrules.
Here is a video of me testing the feature https://www.youtube.com/watch?v=9rIncuNMj9U (vid was too large for GitHub).
PR for issue- #628 


