### PR TITLE
Store each chat in its own key

### DIFF
--- a/src/vs/workbench/contrib/void/browser/chatThreadService.ts
+++ b/src/vs/workbench/contrib/void/browser/chatThreadService.ts
@@ -390,7 +390,7 @@ class ChatThreadService extends Disposable implements IChatThreadService {
 
 	// !!! this is important for properly restoring URIs from storage
 	// should probably re-use code from void/src/vs/base/common/marshalling.ts instead. but this is simple enough
-	private _convertThreadDataFromStorageV2(threadsStr: string): ChatThreads {
+	private _convertThreadDataFromStorage<T>(threadsStr: string): T {
 		return JSON.parse(threadsStr, (key, value) => {
 			if (value && typeof value === 'object' && value.$mid === 1) { // $mid is the MarshalledId. $mid === 1 means it is a URI
 				return URI.from(value); // TODO URI.revive instead of this?
@@ -404,20 +404,9 @@ class ChatThreadService extends Disposable implements IChatThreadService {
 		if (!threadsStr) {
 			return null
 		}
-		const threads = this._convertThreadDataFromStorageV2(threadsStr);
+		const threads = this._convertThreadDataFromStorage<ChatThreads>(threadsStr);
 
 		return threads
-	}
-
-	// !!! this is important for properly restoring URIs from storage
-	// should probably re-use code from void/src/vs/base/common/marshalling.ts instead. but this is simple enough
-	private _convertThreadDataFromStorage(threadStr: string): ThreadType {
-		return JSON.parse(threadStr, (key, value) => {
-			if (value && typeof value === 'object' && value.$mid === 1) { // $mid is the MarshalledId. $mid === 1 means it is a URI
-				return URI.from(value); // TODO URI.revive instead of this?
-			}
-			return value;
-		});
 	}
 
 	private _readThreadIds(): string[] {
@@ -430,7 +419,7 @@ class ChatThreadService extends Disposable implements IChatThreadService {
 		const threads = threadIds
 			.map(id => this._storageService.get(this._storageKey(id), StorageScope.APPLICATION))
 			.filter(t => t)
-			.map(t => this._convertThreadDataFromStorage(t!))
+			.map(t => this._convertThreadDataFromStorage<ThreadType>(t!))
 		if (!threads.length) {
 			return null
 		}

--- a/src/vs/workbench/contrib/void/common/storageKeys.ts
+++ b/src/vs/workbench/contrib/void/common/storageKeys.ts
@@ -16,4 +16,8 @@ export const VOID_SETTINGS_STORAGE_KEY = 'void.settingsServiceStorageII'
 // 'void.chatThreadStorageI' // 1.0.2
 
 // 1.0.3
-export const THREAD_STORAGE_KEY = 'void.chatThreadStorageII'
+// This key is used for migrating from version II to III
+export const THREAD_STORAGE_KEY_II = 'void.chatThreadStorageII'
+
+// 1.3.10
+export const THREAD_STORAGE_KEY_III = 'void.chatThreadStorageIII'


### PR DESCRIPTION
#481 Store each chat in it's own key
    
## Performance Tests

These are performance tests for _readAllThreads. This is the function that could have worse performance. Attempted to make chat length somewhat representative when testing.

```
| Number of Chats | Time in ms |
| --------------- | ---------- |
| 100             | 46ms       |
| 150             | 60ms       |
| 200             | 79ms       |
```

The performance seems good. I could use some help testing performance if anyone has a large chat history!