### PR TITLE
fix: mcp tool call and tool call error response

### DIFF
--- a/src/vs/workbench/contrib/void/electron-main/mcpChannel.ts
+++ b/src/vs/workbench/contrib/void/electron-main/mcpChannel.ts
@@ -245,6 +245,10 @@ export class MCPChannel implements IServerChannel {
 		}
 	}
 
+	private _removeUniquePrefix(name: string) {
+		return name.split('_').slice(1).join('_')
+	}
+
 	private async _closeAllMCPServers() {
 		for (const serverName in this.infoOfClientId) {
 			await this._closeClient(serverName)
@@ -310,7 +314,7 @@ export class MCPChannel implements IServerChannel {
 
 		// Call the tool with the provided parameters
 		const response = await client.callTool({
-			name: toolName,
+			name: this._removeUniquePrefix(toolName),
 			arguments: params
 		})
 		const { content } = response as CallToolResult
@@ -320,8 +324,7 @@ export class MCPChannel implements IServerChannel {
 			// handle text response
 
 			if (response.isError) {
-				throw new Error(`Tool call error: ${response.content}`)
-				// handle error
+				throw new Error(`Tool call error: ${returnValue.text}`)
 			}
 
 			// handle success


### PR DESCRIPTION
## Summary
Fixed tool call errors and how errors are sent back

## Description
- Fixed tool call by removing the prefix before calling the tool
- Fixed the response of tool call error by sending back the text string rather than the content object

## Maintainers
@andrewpareles 