### PR TITLE
openai compatible support reasoning_content field

### DIFF
--- a/src/vs/workbench/contrib/void/common/modelCapabilities.ts
+++ b/src/vs/workbench/contrib/void/common/modelCapabilities.ts
@@ -1233,6 +1233,7 @@ const openaiCompatible: VoidStaticProviderInfo = {
 	providerReasoningIOSettings: {
 		// reasoning: we have no idea what endpoint they used, so we can't consistently parse out reasoning
 		input: { includeInPayload: openAICompatIncludeInPayloadReasoning },
+		output: { nameOfFieldInDelta: 'reasoning_content' },
 	},
 }
 


### PR DESCRIPTION
make openai compatible provider also support `reasoning_content` field