### PR TITLE
Code Clarity Improvements, Bug Fixes, and Cleanup (JSON Serialization, Typo Corrections, Redundant Listener Removal)

### DIFF
--- a/cli/src/commands/output.rs
+++ b/cli/src/commands/output.rs
@@ -65,21 +65,28 @@ impl TablePrinter for JsonTablePrinter {
 		let mut bw = BufWriter::new(out);
 		bw.write_all(b"[")?;
 
-		if !table.cols.is_empty() {
-			let data_len = table.cols[0].data.len();
-			for i in 0..data_len {
-				if i > 0 {
-					bw.write_all(b",{")?;
-				} else {
-					bw.write_all(b"{")?;
-				}
-				for col in &table.cols {
-					serde_json::to_writer(&mut bw, col.heading)?;
-					bw.write_all(b":")?;
-					serde_json::to_writer(&mut bw, &col.data[i])?;
-				}
-			}
-		}
+                if !table.cols.is_empty() {
+                        let data_len = table.cols[0].data.len();
+                        for i in 0..data_len {
+                                if i > 0 {
+                                        bw.write_all(b",")?;
+                                }
+
+                                bw.write_all(b"{")?;
+
+                                for (j, col) in table.cols.iter().enumerate() {
+                                        if j > 0 {
+                                                bw.write_all(b",")?;
+                                        }
+
+                                        serde_json::to_writer(&mut bw, col.heading)?;
+                                        bw.write_all(b":")?;
+                                        serde_json::to_writer(&mut bw, &col.data[i])?;
+                                }
+
+                                bw.write_all(b"}")?;
+                        }
+                }
 
 		bw.write_all(b"]")?;
 		bw.flush()

--- a/src/vs/workbench/contrib/void/browser/react/src/markdown/ChatMarkdownRender.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/markdown/ChatMarkdownRender.tsx
@@ -288,7 +288,7 @@ const RenderToken = ({ token, inPTag, codeURI, chatMessageLocation, tokenIdx, ..
 
 		if (!contents) return null
 
-		// figure out langauge and URI
+                // figure out language and URI
 		let uri: URI | null
 		let language: string
 		if (codeURI) {

--- a/src/vs/workbench/services/treeSitter/browser/treeSitterCodeEditors.ts
+++ b/src/vs/workbench/services/treeSitter/browser/treeSitterCodeEditors.ts
@@ -89,9 +89,9 @@ export class TreeSitterCodeEditors extends Disposable {
 				this._textModels.add(model);
 			}
 			if (!this._languageEditors.has(editor)) {
-				const langaugeEditorDisposables = new DisposableStore();
-				langaugeEditorDisposables.add(editor.onDidScrollChange(() => this._onViewportChange(editor), this));
-				this._languageEditors.set(editor, langaugeEditorDisposables);
+                               const languageEditorDisposables = new DisposableStore();
+                               languageEditorDisposables.add(editor.onDidScrollChange(() => this._onViewportChange(editor), this));
+                               this._languageEditors.set(editor, languageEditorDisposables);
 				this._onViewportChange(editor);
 			}
 		}

--- a/test/monaco/monaco.test.ts
+++ b/test/monaco/monaco.test.ts
@@ -42,14 +42,10 @@ beforeEach(async function () {
 	});
 
 	pageErrors.length = 0;
-	page.on('pageerror', (e) => {
-		console.log(e);
-		pageErrors.push(e);
-	});
-	page.on('pageerror', (e) => {
-		console.log(e);
-		pageErrors.push(e);
-	});
+       page.on('pageerror', (e) => {
+               console.log(e);
+               pageErrors.push(e);
+       });
 });
 
 afterEach(async () => {


### PR DESCRIPTION
This pull request includes several changes across different files, focusing on code formatting improvements, bug fixes, and minor refactoring. The most notable changes involve fixing typos, improving JSON serialization logic, and removing redundant event listeners.

### Code Formatting Improvements:
* [`src/vs/workbench/contrib/void/browser/react/src/markdown/ChatMarkdownRender.tsx`](diffhunk://#diff-7ff79335fcf50be7d913363251d6451a6e27b1de5662858c8e987d2fd3d8ee85L291-R291): Corrected the indentation of a comment for better readability.
* [`src/vs/workbench/services/treeSitter/browser/treeSitterCodeEditors.ts`](diffhunk://#diff-09fb7fa7ae31d208ced10eff87aae55319957649c83d13fdaee33dacaf6be4e9L92-R94): Fixed the spelling of `languageEditorDisposables` and adjusted the indentation for consistent formatting.

### Bug Fixes:
* [`cli/src/commands/output.rs`](diffhunk://#diff-9d7f170e4c5b18bfa10cbc8803defa2ec85f7a92b2bbfa2dc92dbcde932714c1L72-R87): Adjusted the JSON serialization logic in the `TablePrinter` implementation to ensure proper formatting by fixing misplaced commas and braces.

### Refactoring:
* [`test/monaco/monaco.test.ts`](diffhunk://#diff-e3420941053b77e18a11b3409f24959b87feee90f35ebc158b492b63e2f9c9e5L49-L52): Removed a redundant `page.on('pageerror')` event listener to avoid duplicate error logging.