### PR TITLE
Fix a Model Sorting Bug in the Settings UI

### DIFF
--- a/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
@@ -400,10 +400,17 @@ export const ModelDump = ({ filteredProviders }: { filteredProviders?: ProviderN
 		modelDump.push(...providerSettings.models.map(model => ({ ...model, providerName, providerEnabled: !!providerSettings._didFillInProviderSettings })))
 	}
 
-	// sort by hidden
+	// sort by hidden, then by provider, then by model name
 	modelDump.sort((a, b) => {
-		return Number(b.providerEnabled) - Number(a.providerEnabled)
-	})
+		// localeCompare sorts ASC: enabled providers are 0, and disabled are 1
+		// eg: `0 ollama llama3.3:70b` vs `1 anthropic claude-3-5-haiku-latest`
+		const aKey = `${Number(!a.providerEnabled)} ${a.providerName} ${a.modelName}`;
+		const bKey = `${Number(!b.providerEnabled)} ${b.providerName} ${b.modelName}`;
+		return aKey.localeCompare(bKey, undefined, {
+			numeric: true,
+			sensitivity: 'base'
+		});
+	});
 
 	// Add model handler
 	const handleAddModel = () => {


### PR DESCRIPTION
# Bug

There is a bug in the Settings UI. If void receives models from an autogenerated list of models (like in the case of querying an ollama server for the models it has), then that autogenerated list may not be sorted. When displayed in the UI, this unordered and autogenerated list may change upon repeated refreshes, resulting in models swapping places around the UI.

# Models position can change across UI updates with existing sort behavior

![sort-models-failure-case](https://github.com/user-attachments/assets/7e476ef9-9ace-4c51-9b5d-a299553c78a1)

# With new sort behavior, model position remains static and orderly

![sort-models-after-changes](https://github.com/user-attachments/assets/abff6742-e741-4119-ae37-372e62454e18)

# Details

This change improves upon the existing sorting and sorts the models according to the following pattern.

`${Number(!a.providerEnabled)} ${a.providerName} ${a.modelName}`;

The pattern results in search string keys that look like this:
```
0 ollama llama3.1:8b
0 ollama llama3.1:70b
0 ollama qwen3:8b
1 anthropic claude-3-5-haiku-latest
1 anthropic claude-3-5-sonnet-latest
1 anthropic claude-3-7-sonnet-latest
```

The `${Number(!a.providerEnabled)}` produces the `0` and `1` in the above pattern.
When these strings are sorted (from left to right) we will start with a number, either 0 or 1.
By setting enabled providers to `0`, and disabled providers to `1`, we prioritize enabled providers to be on top.
This is the goal as the original sorting algorithm.

Next the `${a.providerName} ${a.modelName}` results in models within a provider being grouped together.
Inside of each provider's group, the models will be sorted alphabetically.

```
0 ollama llama3.1:8b     // ollama models are grouped together
0 ollama llama3.1:70b    // ollama models are grouped together
0 ollama qwen3:8b        // ollama models are grouped together
1 anthropic claude-3-5-haiku-latest   // anthropic models are grouped together
1 anthropic claude-3-5-sonnet-latest  // anthropic models are grouped together
1 anthropic claude-3-7-sonnet-latest  // anthropic models are grouped together
```

By using `numeric: true` for the `localCompare` function, we ensure that when we encounter a number, that number is parsed and compared. This is how the 0, and 1 are compared, but also enables us to sort by model name & size.

```
0 ollama llama3.1:8b                  // 8 is smaller than 70, so it is further up the list 
0 ollama llama3.1:70b
0 ollama qwen3:8b
1 anthropic claude-3-5-haiku-latest   // 1 (disabled) is larger than 0 (enabled), so it its further down the list
```





