### PR TITLE
Void sending Telemetry, snitching despite settings

### DIFF
--- a/src/vs/workbench/contrib/void/electron-main/metricsMainService.ts
+++ b/src/vs/workbench/contrib/void/electron-main/metricsMainService.ts
@@ -75,22 +75,22 @@ export class MetricsMainService extends Disposable implements IMetricsService {
 	}
 
 	// just to see if there are ever multiple machineIDs per userID (instead of this, we should just track by the user's email)
-	private get userId() {
-		return this._memoStorage('void.app.userMachineId', StorageTarget.USER)
-	}
-
-	constructor(
-		@IProductService private readonly _productService: IProductService,
-		@IEnvironmentMainService private readonly _envMainService: IEnvironmentMainService,
-		@IApplicationStorageMainService private readonly _appStorage: IApplicationStorageMainService,
-	) {
-		super()
-		this.client = new PostHog('phc_UanIdujHiLp55BkUTjB1AuBXcasVkdqRwgnwRlWESH2', {
-			host: 'https://us.i.posthog.com',
-		})
-
-		this.initialize() // async
-	}
+	//private get userId() {
+	//	return this._memoStorage('void.app.userMachineId', StorageTarget.USER)
+	//}
+	//
+	//constructor(
+	//	@IProductService private readonly _productService: IProductService,
+	//	@IEnvironmentMainService private readonly _envMainService: IEnvironmentMainService,
+	//	@IApplicationStorageMainService private readonly _appStorage: IApplicationStorageMainService,
+	//) {
+	//	super()
+	//	this.client = new PostHog('phc_UanIdujHiLp55BkUTjB1AuBXcasVkdqRwgnwRlWESH2', {
+	//		host: 'https://us.i.posthog.com',
+	//	})
+	//
+	//	this.initialize() // async
+	//}
 
 	async initialize() {
 		// very important to await whenReady!


### PR DESCRIPTION
This code does not respect the users telemetry settings.

It specifically calls a 3rd party telemetry service with detailed user information, os information and build info, without consent.

The payload contains:
A unique ID for your machine
An ID regarding your user profile
Git hash of the build
Version of VSCode
Version of Void
Release channel
Quality of build
Detailed information regarding your operating system and its system specifics
If void is running in dev mode

This was specifically added by the void contributors and is not vestigial code. It was added very recently, after void telem settings were implemented.

This was likely intentional, given how 'transparent' void is with its users regarding data and its policies, it is difficult to imagine a contrary case.

This user, andrewpareles, should be investigated for conflicts of interest, and relationships with these third party telemetry service providers.