### PR TITLE
Fix: IME composition preventing message sending in chat

### DIFF
--- a/src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarChat.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarChat.tsx
@@ -1121,7 +1121,7 @@ const UserMessageComponent = ({ chatMessage, messageIdx, isCheckpointGhost, curr
 			if (e.key === 'Escape') {
 				onCloseEdit()
 			}
-			if (e.key === 'Enter' && !e.shiftKey) {
+			if (e.key === 'Enter' && !e.shiftKey && !(e.nativeEvent as any).isComposing) {
 				onSubmit()
 			}
 		}
@@ -3048,7 +3048,7 @@ export const SidebarChat = () => {
 		setInstructionsAreEmpty(!newStr)
 	}, [setInstructionsAreEmpty])
 	const onKeyDown = useCallback((e: KeyboardEvent<HTMLTextAreaElement>) => {
-		if (e.key === 'Enter' && !e.shiftKey) {
+		if (e.key === 'Enter' && !e.shiftKey && !(e.nativeEvent as any).isComposing) {
 			onSubmit()
 		} else if (e.key === 'Escape' && isRunning) {
 			onAbort()


### PR DESCRIPTION
Fix: IME composition preventing message sending in chat

This pull request addresses an issue where the Enter key would automatically send a message in the AI chat while the user was still composing Japanese characters using an Input Method Editor (IME).

The problem was that the keydown event listener for sending messages didn't account for IME composition. As a result, the Enter key would trigger the send action even when it was intended to finalize the character composition.

This commit modifies the `onKeyDown` handler in `src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarChat.tsx` to check `!(e.nativeEvent as any).isComposing` before sending the message. This ensures that the message is only sent when the user has finished composing their input.

This change prevents accidental message sends and improves the user experience for users who rely on IMEs for text input.

Testing:

- Verified that the Enter key no longer sends messages prematurely when composing Japanese characters with an IME.