### PR TITLE
Fix IME composition handling in input box

### DIFF
--- a/scripts/code.sh
+++ b/scripts/code.sh
@@ -51,7 +51,7 @@ function code() {
 	exec "$CODE" . $DISABLE_TEST_EXTENSION "$@"
 }
 
-function code-wsl()
+function code_wsl()
 {
 	HOST_IP=$(echo "" | powershell.exe -noprofile -Command "& {(Get-NetIPAddress | Where-Object {\$_.InterfaceAlias -like '*WSL*' -and \$_.AddressFamily -eq 'IPv4'}).IPAddress | Write-Host -NoNewline}")
 	export DISPLAY="$HOST_IP:0"
@@ -77,7 +77,7 @@ function code-wsl()
 }
 
 if [ "$IN_WSL" == "true" ] && [ -z "$DISPLAY" ]; then
-	code-wsl "$@"
+	code_wsl "$@"
 elif [ -f /mnt/wslg/versions.txt ]; then
 	code --disable-gpu "$@"
 elif [ -f /.dockerenv ]; then

--- a/src/vs/workbench/contrib/void/browser/react/src/util/inputs.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/util/inputs.tsx
@@ -797,7 +797,10 @@ export const VoidInputBox2 = forwardRef<HTMLTextAreaElement, InputBox2Props>(fun
 				if (e.key === 'Enter') {
 					// Shift + Enter when multiline = newline
 					const shouldAddNewline = e.shiftKey && multiline
-					if (!shouldAddNewline) e.preventDefault(); // prevent newline from being created
+					// 只有在非输入法组合状态下才阻止默认行为
+					if (!shouldAddNewline && !e.nativeEvent.isComposing) {
+						e.preventDefault(); // prevent newline from being created
+					}
 				}
 				onKeyDown?.(e)
 			}, [onKeyDown, onMenuKeyDown, multiline])}


### PR DESCRIPTION
- Add isComposing check before preventDefault() in VoidInputBox2
- Prevents Enter key from triggering AI chat when IME is in composition state
- Allows proper confirmation of English input during Chinese IME usage
- Fixes issue where users couldn't complete input when using Chinese input methods