### PR TITLE
Removed Redundant Settings Gear Icon

### DIFF
--- a/src/vs/workbench/contrib/void/browser/sidebarActions.ts
+++ b/src/vs/workbench/contrib/void/browser/sidebarActions.ts
@@ -17,7 +17,7 @@ import { IRange } from '../../../../editor/common/core/range.js';
 import { VOID_VIEW_CONTAINER_ID, VOID_VIEW_ID } from './sidebarPane.js';
 import { IMetricsService } from '../common/metricsService.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
-import { VOID_TOGGLE_SETTINGS_ACTION_ID } from './voidSettingsPane.js';
+// import { VOID_TOGGLE_SETTINGS_ACTION_ID } from './voidSettingsPane.js'; // Commented out - not needed since settings action is removed
 import { VOID_CTRL_L_ACTION_ID } from './actionIDs.js';
 import { localize2 } from '../../../../nls.js';
 import { IChatThreadService } from './chatThreadService.js';
@@ -235,21 +235,22 @@ registerAction2(class extends Action2 {
 })
 
 
-// Settings gear
-registerAction2(class extends Action2 {
-	constructor() {
-		super({
-			id: 'void.settingsAction',
-			title: `Void's Settings`,
-			icon: { id: 'settings-gear' },
-			menu: [{ id: MenuId.ViewTitle, group: 'navigation', when: ContextKeyExpr.equals('view', VOID_VIEW_ID), }]
-		});
-	}
-	async run(accessor: ServicesAccessor): Promise<void> {
-		const commandService = accessor.get(ICommandService)
-		commandService.executeCommand(VOID_TOGGLE_SETTINGS_ACTION_ID)
-	}
-})
+// Settings gear - Commented out to remove redundant settings icon in the AI chat panel
+// The main settings gear in the IDE's top bar remains functional
+// registerAction2(class extends Action2 {
+// 	constructor() {
+// 		super({
+// 			id: 'void.settingsAction',
+// 			title: `Void's Settings`,
+// 			icon: { id: 'settings-gear' },
+// 			menu: [{ id: MenuId.ViewTitle, group: 'navigation', when: ContextKeyExpr.equals('view', VOID_VIEW_ID), }]
+// 		});
+// 	}
+// 	async run(accessor: ServicesAccessor): Promise<void> {
+// 		const commandService = accessor.get(ICommandService)
+// 		commandService.executeCommand('VOID_TOGGLE_SETTINGS_ACTION_ID')
+// 	}
+// })
 
 
 


### PR DESCRIPTION
# Notes on Changes Made

## 2025-01-26: Removed Redundant Settings Gear Icon

**File Modified:**  
`void/src/vs/workbench/contrib/void/browser/sidebarActions.ts`

**Change:**  
Commented out the settings gear action registration (lines 238-253) to remove the redundant settings icon from the AI chat panel's title bar.

**Reason:**  
The settings gear icon in the right-side AI chat panel was redundant, as an identical icon already exists in the IDE's top bar. This update enhances UI clarity by eliminating duplicate functionality.

**Details:**  
- **Action ID Removed:** `void.settingsAction`  
- The primary settings functionality in the IDE's top bar remains unchanged.  
- The commented-out code is preserved for potential future reference or reversion.

![Screenshot 2025-07-27 at 00:42:09](https://github.com/user-attachments/assets/bc9b3ea2-6ac0-4b84-993b-f7aef9c03281)