### PR TITLE
Updated code selection to properly parse selected lines

### DIFF
--- a/src/vs/workbench/contrib/void/common/prompt/prompts.ts
+++ b/src/vs/workbench/contrib/void/common/prompt/prompts.ts
@@ -577,16 +577,21 @@ export const messageOfSelection = async (
 
 	if (s.type === 'CodeSelection') {
 		const { val } = await readFile(opts.fileService, s.uri, DEFAULT_FILE_SIZE_LIMIT)
-		const lineNumAdd = lineNumAddition(s.range)
 		const lines = val?.split('\n')
-		const selection = `${tripleTick[0]}${s.language}\n${lines?.slice(s.range[0] - 1, s.range[1]).join('\n')}\n${tripleTick[1]}`
-		const content = selection ?? 'null'
-		const str = `${s.uri.fsPath}${lineNumAdd}:\n${content}`
+
+		const innerVal = lines?.slice(s.range[0] - 1, s.range[1]).join('\n')
+		const content = !lines ? ''
+			: `${tripleTick[0]}${s.language}\n${innerVal}\n${tripleTick[1]}`
+		const str = `${s.uri.fsPath}${lineNumAddition(s.range)}:\n${content}`
 		return str
 	}
 	else if (s.type === 'File') {
 		const { val } = await readFile(opts.fileService, s.uri, DEFAULT_FILE_SIZE_LIMIT)
-		const content = val === null ? 'null' : `${tripleTick[0]}${s.language}\n${val}\n${tripleTick[1]}`
+
+		const innerVal = val
+		const content = val === null ? ''
+			: `${tripleTick[0]}${s.language}\n${innerVal}\n${tripleTick[1]}`
+
 		const str = `${s.uri.fsPath}:\n${content}`
 		return str
 	}

--- a/src/vs/workbench/contrib/void/common/prompt/prompts.ts
+++ b/src/vs/workbench/contrib/void/common/prompt/prompts.ts
@@ -579,7 +579,7 @@ export const messageOfSelection = async (
 		const { val } = await readFile(opts.fileService, s.uri, DEFAULT_FILE_SIZE_LIMIT)
 		const lineNumAdd = lineNumAddition(s.range)
 		const lines = val?.split('\n')
-		const selection = lines?.slice(s.range[0] - 1, s.range[1]).join('\n')
+		const selection = `${tripleTick[0]}${s.language}\n${lines?.slice(s.range[0] - 1, s.range[1]).join('\n')}\n${tripleTick[1]}`
 		const content = selection ?? 'null'
 		const str = `${s.uri.fsPath}${lineNumAdd}:\n${content}`
 		return str

--- a/src/vs/workbench/contrib/void/common/prompt/prompts.ts
+++ b/src/vs/workbench/contrib/void/common/prompt/prompts.ts
@@ -577,7 +577,7 @@ export const messageOfSelection = async (
 
 	if (s.type === 'CodeSelection') {
 		const { val } = await readFile(opts.fileService, s.uri, DEFAULT_FILE_SIZE_LIMIT)
-		const lineNumAdd = s.type === 'CodeSelection' ? lineNumAddition(s.range) : ''
+		const lineNumAdd = lineNumAddition(s.range)
 		const lines = val?.split('\n')
 		const selection = lines?.slice(s.range[0] - 1, s.range[1]).join('\n')
 		const content = selection ?? 'null'

--- a/src/vs/workbench/contrib/void/common/prompt/prompts.ts
+++ b/src/vs/workbench/contrib/void/common/prompt/prompts.ts
@@ -575,11 +575,19 @@ export const messageOfSelection = async (
 ) => {
 	const lineNumAddition = (range: [number, number]) => ` (lines ${range[0]}:${range[1]})`
 
-	if (s.type === 'File' || s.type === 'CodeSelection') {
+	if (s.type === 'CodeSelection') {
 		const { val } = await readFile(opts.fileService, s.uri, DEFAULT_FILE_SIZE_LIMIT)
 		const lineNumAdd = s.type === 'CodeSelection' ? lineNumAddition(s.range) : ''
-		const content = val === null ? 'null' : `${tripleTick[0]}${s.language}\n${val}\n${tripleTick[1]}`
+		const lines = val?.split('\n')
+		const selection = lines?.slice(s.range[0] - 1, s.range[1]).join('\n')
+		const content = selection ?? 'null'
 		const str = `${s.uri.fsPath}${lineNumAdd}:\n${content}`
+		return str
+	}
+	else if (s.type === 'File') {
+		const { val } = await readFile(opts.fileService, s.uri, DEFAULT_FILE_SIZE_LIMIT)
+		const content = val === null ? 'null' : `${tripleTick[0]}${s.language}\n${val}\n${tripleTick[1]}`
+		const str = `${s.uri.fsPath}:\n${content}`
 		return str
 	}
 	else if (s.type === 'Folder') {


### PR DESCRIPTION
## Notes on Changes Made

**Date:** 2025-08-03  
**File Modified:** `void/src/vs/workbench/contrib/void/common/prompt/prompts.ts`  
**Issue Reference:** [#810](https://github.com/voideditor/void/issues/810)

### Summary

Updated `messageOfSelection` to correctly parse selected lines when the user presses **CMD + L**, resolving an issue where the entire file was previously being passed instead of the intended selection.

### Change Details (Lines 578–592)

- Updated logic handling different `StagingSelectionItem` types:
  - Split logic paths more clearly between **CodeSelection** and **File**.
- Revised the **CodeSelection** branch to:
  - Convert the file’s content into an array of lines.
  - Extract only the lines that fall within the user’s selected range.

### Reason

When users selected specific lines, the entire file was previously being sent to the model. This resulted in difficulty for some models to isolate and focus on the user-specified context. By sending only the selected lines, selection intent is preserved, leading to more accurate behavior.

<img width="1571" height="422" alt="image" src="https://github.com/user-attachments/assets/57588f8f-6483-401c-b668-7c46bd93500d" />
