### PR TITLE
Add configuration settings for prompt and terminal related activities

### DIFF
--- a/src/vs/workbench/contrib/void/browser/editCodeService.ts
+++ b/src/vs/workbench/contrib/void/browser/editCodeService.ts
@@ -1408,7 +1408,7 @@ class EditCodeService extends Disposable implements IEditCodeService {
 
 			const startLine = startRange === 'fullFile' ? 1 : startRange[0]
 			const endLine = startRange === 'fullFile' ? model.getLineCount() : startRange[1]
-			const { prefix, suffix } = voidPrefixAndSuffix({ fullFileStr: originalFileCode, startLine, endLine })
+			const { prefix, suffix } = voidPrefixAndSuffix({ settingsService: this._settingsService, fullFileStr: originalFileCode, startLine, endLine })
 			const userContent = ctrlKStream_userMessage({ selection: originalCode, instructions: instructions, prefix, suffix, fimTags: quickEditFIMTags, language })
 
 			const { messages: a, separateSystemMessage: b } = this._convertToLLMMessageService.prepareLLMSimpleMessages({

--- a/src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarChat.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarChat.tsx
@@ -28,7 +28,7 @@ import { approvalTypeOfBuiltinToolName, BuiltinToolCallParams, BuiltinToolName, 
 import { CopyButton, EditToolAcceptRejectButtonsHTML, IconShell1, JumpToFileButton, JumpToTerminalButton, StatusIndicator, StatusIndicatorForApplyButton, useApplyStreamState, useEditToolStreamState } from '../markdown/ApplyBlockHoverButtons.js';
 import { IsRunningType } from '../../../chatThreadService.js';
 import { acceptAllBg, acceptBorder, buttonFontSize, buttonTextColor, rejectAllBg, rejectBg, rejectBorder } from '../../../../common/helpers/colors.js';
-import { builtinToolNames, isABuiltinToolName, MAX_FILE_CHARS_PAGE, MAX_TERMINAL_INACTIVE_TIME } from '../../../../common/prompt/prompts.js';
+import { builtinToolNames, isABuiltinToolName } from '../../../../common/prompt/prompts.js';
 import { RawToolCallObj } from '../../../../common/sendLLMMessageTypes.js';
 import ErrorBoundary from './ErrorBoundary.js';
 import { ToolApprovalTypeSwitch } from '../void-settings-tsx/Settings.js';
@@ -1946,7 +1946,7 @@ const builtinToolNameToComponent: { [T in BuiltinToolName]: { resultWrapper: Res
 				const { result } = toolMessage
 				componentParams.onClick = () => { voidOpenFileFn(params.uri, accessor, range) }
 				if (result.hasNextPage && params.pageNumber === 1)  // first page
-					componentParams.desc2 = `(truncated after ${Math.round(MAX_FILE_CHARS_PAGE) / 1000}k)`
+					componentParams.desc2 = '(truncated)'
 				else if (params.pageNumber > 1) // subsequent pages
 					componentParams.desc2 = `(part ${params.pageNumber})`
 			}

--- a/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
+++ b/src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx
@@ -799,26 +799,26 @@ export const AIInstructionsBox = () => {
 }
 
 export const LimitComponent = ({ setting, onVoidSettingsInit, onVoidDefaultSettingsInit }: {
-  setting: GlobalSettingName
-  onVoidSettingsInit: (state: VoidSettingsState) => number
-  onVoidDefaultSettingsInit: (settings: GlobalSettings) => number
+  	setting: GlobalSettingName
+  	onVoidSettingsInit: (state: VoidSettingsState) => number
+  	onVoidDefaultSettingsInit: (settings: GlobalSettings) => number
 }) => {
 	const accessor = useAccessor()
 	const voidSettingsService = accessor.get('IVoidSettingsService')
 	const voidSettingsState = useSettingsState()
 	const [name, description] = displayNameAndDescriptionOfSetting(setting)
-  return (
-    <div className="flex flex-col gap-1">
-      <h4 className="text-base">{name}</h4>
-      {description && (
-        <div className="text-sm text-void-fg-3 mt-1">
-          <span>{description}</span>
-        </div>
-      )}
-      <VoidSimpleInputBox
-        value={onVoidSettingsInit(voidSettingsState)?.toString() ?? onVoidDefaultSettingsInit(defaultGlobalSettings)}
-        placeholder={`Default: ${onVoidDefaultSettingsInit(defaultGlobalSettings)}`}
-        onChangeValue={(newVal) => {
+  	return (
+		<div className="flex flex-col gap-1">
+			<h4 className="text-base">{name}</h4>
+			{description && (
+				<div className="text-sm text-void-fg-3 mt-1">
+				<span>{description}</span>
+				</div>
+			)}
+			<VoidSimpleInputBox
+				value={onVoidSettingsInit(voidSettingsState)?.toString() ?? onVoidDefaultSettingsInit(defaultGlobalSettings)}
+				placeholder={`Default: ${onVoidDefaultSettingsInit(defaultGlobalSettings)}`}
+				onChangeValue={(newVal) => {
 					const parsed = parseInt(newVal)
 					if (!parsed || isNaN(parsed)) {
 						return
@@ -826,18 +826,15 @@ export const LimitComponent = ({ setting, onVoidSettingsInit, onVoidDefaultSetti
 
 					voidSettingsService.setGlobalSetting(setting, parsed >= 0 ? parsed : 0)
 				}}
-      />
-    </div>
-  )
+			/>
+    	</div>
+  	)
 }
 
 
 export const LimitsList = ({ settings }: { settings: GlobalSettingName[] }) => {
-  let content: React.ReactNode
-  if (settings.length === 0) {
-    content = <div className="text-void-fg-3 text-sm mt-2">N/A</div>
-  } else {
-    content = (
+  	return (
+		<div className="my-2">
 			<div className="flex flex-col gap-2">
 				{settings.map((setting) => (
 					<LimitComponent
@@ -848,9 +845,8 @@ export const LimitsList = ({ settings }: { settings: GlobalSettingName[] }) => {
 					/>
 				))}
 			</div>
-		)
-  }
-  return <div className="my-2">{content}</div>
+		</div>
+	)
 }
 
 const FastApplyMethodDropdown = () => {

--- a/src/vs/workbench/contrib/void/common/voidSettingsTypes.ts
+++ b/src/vs/workbench/contrib/void/common/voidSettingsTypes.ts
@@ -384,6 +384,66 @@ export const displayInfoOfFeatureName = (featureName: FeatureName) => {
 		throw new Error(`Feature Name ${featureName} not allowed`)
 }
 
+export function displayNameAndDescriptionOfSetting(
+	setting: string
+): [name: string, description: string] {
+	const settingsMap: Record<string, [name: string, description: string]> = {
+		// directoryStructureLimits
+		maxDirstrCharsTotalBeginning: [
+			'Max Directory Structure Chars (Beginning)',
+			'Maximum number of characters from the beginning of the directory structure representation to include in initial context.',
+		],
+		maxDirstrCharsTotalTool: [
+			'Max Directory Structure Chars (Tool)',
+			'Maximum number of characters from the directory structure representation to include when using the directory listing tool.',
+		],
+		maxDirstrResultsTotalBeginning: [
+			'Max Directory Structure Results (Beginning)',
+			'Maximum number of directory entries (files/folders) to include in the initial context before truncation.',
+		],
+		maxDirstrResultsTotalTool: [
+			'Max Directory Structure Results (Tool)',
+			'Maximum number of directory entries (files/folders) to return when explicitly listing directory contents via tool.',
+		],
+
+		// toolInfoLimits
+		maxFileCharsPage: [
+			'Max File Characters per Page',
+			'Maximum number of characters allowed when reading file content in a single tool call or page.',
+		],
+		maxChildrenUrisPage: [
+			'Max Children URIs per Page',
+			'Maximum number of child URIs (e.g. files in a directory) that can be listed in a single page.',
+		],
+
+		// terminalInfoLimits
+		maxTerminalChars: [
+			'Max Terminal Characters',
+			'Maximum number of characters to capture from terminal output before truncation.',
+		],
+		maxTerminalInactiveTime: [
+			'Max Terminal Inactive Time',
+			'Maximum time (in seconds) a terminal session can remain inactive before being terminated.',
+		],
+		maxTerminalBgCommandTime: [
+			'Max Terminal Background Command Time',
+			'Maximum time (in seconds) a background terminal command can run before timing out.',
+		],
+
+		// contextLimits
+		maxPrefixSuffixChars: [
+			'Max Prefix Suffix Characters',
+			'Maximum number of characters to include as prefix/suffix context around edits or suggestions.',
+		],
+	};
+
+	if (!(setting in settingsMap)) {
+		throw new Error(`Unknown setting: "${setting}". Valid settings are: ${Object.keys(settingsMap).join(', ')}`);
+	}
+
+	return settingsMap[setting];
+}
+
 
 // the models of these can be refreshed (in theory all can, but not all should)
 export const refreshableProviderNames = localProviderNames
@@ -452,6 +512,16 @@ export type GlobalSettings = {
 	isOnboardingComplete: boolean;
 	disableSystemMessage: boolean;
 	autoAcceptLLMChanges: boolean;
+	maxDirstrCharsTotalBeginning: number;
+	maxDirstrCharsTotalTool: number;
+	maxDirstrResultsTotalBeginning: number;
+	maxDirstrResultsTotalTool: number;
+	maxFileCharsPage: number;
+	maxChildrenUrisPage: number;
+	maxTerminalChars: number;
+	maxTerminalInactiveTime: number;
+	maxTerminalBgCommandTime: number;
+	maxPrefixSuffixChars: number;
 }
 
 export const defaultGlobalSettings: GlobalSettings = {
@@ -468,6 +538,16 @@ export const defaultGlobalSettings: GlobalSettings = {
 	isOnboardingComplete: false,
 	disableSystemMessage: false,
 	autoAcceptLLMChanges: false,
+	maxDirstrCharsTotalBeginning: 20_000,
+	maxDirstrCharsTotalTool: 20_000,
+	maxDirstrResultsTotalBeginning: 100,
+	maxDirstrResultsTotalTool: 100,
+	maxFileCharsPage: 500_000,
+	maxChildrenUrisPage: 500,
+	maxTerminalChars: 100_000,
+	maxTerminalInactiveTime: 8,
+	maxTerminalBgCommandTime: 5,
+	maxPrefixSuffixChars: 20_000,
 }
 
 export type GlobalSettingName = keyof GlobalSettings


### PR DESCRIPTION
Let me know if there's any changes needed on my end! :)

# Notes on Changes Made

**Date**: 2025-08-08
**Files Modified**: 
- `src/vs/workbench/contrib/void/browser/editCodeService.ts`
- `src/vs/workbench/contrib/void/browser/react/src/sidebar-tsx/SidebarChat.tsx`
- `src/vs/workbench/contrib/void/browser/react/src/void-settings-tsx/Settings.tsx`
- `src/vs/workbench/contrib/void/browser/terminalToolService.ts`
- `src/vs/workbench/contrib/void/browser/toolsService.ts`
- `src/vs/workbench/contrib/void/common/directoryStrService.ts`
- `src/vs/workbench/contrib/void/common/prompt/prompts.ts`
- `src/vs/workbench/contrib/void/common/voidSettingsTypes.ts`

**Issue Reference**: 
- #728 
- #750 

## Summary

Updated `messageOfSelection` to correctly parse selected lines when the user presses `CMD + L`, resolving an issue where the entire file was previously being passed instead of the intended selection.

## Change Details
- Added `Settings` React components to include new section for a "Limits" section:
    - Created a `LimitComponent` and accompanying `LimitsList` to display different subsections for the settings
        -  Note: components include checks to ensure values are valid, non-negative numbers 
- Updated the settings to include new values in `GlobalSettings` for previously hard-coded values found in `prompts.ts`
- Updated relevant services to reference the new settings in `GlobalSettings`

## Reason
The above issues mention eventually adding the ability to configure settings related to limits on prompt and terminal related actions. This aims to address those issues while staying as consistent as possible with the original code-base.

## Images
<img width="956" height="1276" alt="image" src="https://github.com/user-attachments/assets/2624dd8c-7830-41c6-90e9-211b8c32d34e" />
