### PR TITLE
Add Swipe to Navigate for macOS touchpads.

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -337,6 +337,58 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'description': localize('mouseBackForwardToNavigate', "Enables the use of mouse buttons four and five for commands 'Go Back' and 'Go Forward'."),
 				'default': true
 			},
+			'workbench.editor.swipeToNavigate': {
+				'oneOf': [
+					{
+						'type': 'string',
+						'enum': [
+							'disabled',
+							'editor',
+							'editorInGroup',
+							'history',
+							'historyInGroup',
+							'group',
+							'navigation',
+							'edit',
+							'navigationEdit'
+						],
+						'enumDescriptions': [
+							localize('swipeToNavigate.disabled', "Disable swipe navigation."),
+							localize('swipeToNavigate.editor', "Switch editor tabs across all groups (previous/next)."),
+							localize('swipeToNavigate.editorInGroup', "Switch editor tabs within the current group only (previous/next)."),
+							localize('swipeToNavigate.history', "Move through most recently used editors (MRU) across all groups (previous/next)."),
+							localize('swipeToNavigate.historyInGroup', "Move through most recently used editors (MRU) within the current group (previous/next)."),
+							localize('swipeToNavigate.group', "Change focus to neighboring editor groups (left/right/up/down)."),
+							localize('swipeToNavigate.navigation', "Move through navigational history (Go To References)."),
+							localize('swipeToNavigate.edit', "Navigate cursor edit locations."),
+							localize('swipeToNavigate.navigationEdit', "Navigate combined navigation and edit history.")
+						]
+					},
+					{
+						'type': 'object',
+						'additionalProperties': false,
+						'properties': {
+							'horizontal': {
+								'default': 'navigationEdit',
+								'oneOf': [
+									{ 'type': 'string', 'enum': ['disabled', 'editor', 'editorInGroup', 'history', 'historyInGroup', 'group', 'navigation', 'edit', 'navigationEdit'] },
+									{ 'type': 'object', 'additionalProperties': false, 'properties': { 'previous': { 'type': 'string' }, 'next': { 'type': 'string' } } }
+								]
+							},
+							'vertical': {
+								'default': 'disabled',
+								'oneOf': [
+									{ 'type': 'string', 'enum': ['disabled', 'editor', 'editorInGroup', 'history', 'historyInGroup', 'group', 'navigation', 'edit', 'navigationEdit'] },
+									{ 'type': 'object', 'additionalProperties': false, 'properties': { 'previous': { 'type': 'string' }, 'next': { 'type': 'string' } } }
+								],
+								'description': localize('swipeToNavigate.vertical', "Override vertical swipe behavior. Note: 'default' is not supported for vertical; use explicit options or omit to disable.")
+							}
+						}
+					}
+				],
+				'markdownDescription': localize('swipeToNavigate', "Configure swipe gesture navigation on macOS touchpads. Accepts 'default'/'disabled', a specific mode (e.g. 'editor', 'history'), or an object that specifies separate 'horizontal' and 'vertical' behavior."),
+				'default': 'navigationEdit'
+			},
 			'workbench.editor.navigationScope': {
 				'type': 'string',
 				'enum': ['default', 'editorGroup', 'editor'],


### PR DESCRIPTION
[Alternative solution](https://github.com/voideditor/void/pull/879) is to expose the event for extensions via the API. 
I've already made the extension for vscode. 

Following options have been added:

- 	`"disabled"` – Disable swipe navigation.
- 	`"editor"` – Switch editor tabs across all groups (previous/next).
- 	`"editorInGroup"` – Switch editor tabs within the current group only (previous/next).
- 	`"history"` – Move through most recently used editors (MRU) across all groups (previous/next).
- 	`"historyInGroup"` – Move through most recently used editors (MRU) within the current group (previous/next).
- 	`"group"` – Change focus to neighboring editor groups (left/right/up/down).
- 	`"navigation"` – Move through navigational history (for example: Go To References).
- 	`"edit"` – Navigate cursor edit locations.
- 	`"navigationEdit"` – Navigate through a combined history of navigation and edit locations.

Alternatively, the setting can be defined as an object:

```json 
"workbench.editor.swipeToNavigate": {
  "horizontal": "navigationEdit",
  "vertical": "disabled"
}
```

Can also support custom actions: 
```json
"workbench.editor.swipeToNavigate": {
  "horizontal": "disabled",
  "vertical": { "previous": "commandId1", "next": "commandId2" }
}
```

Requires these OS settings: 
![image](https://github.com/user-attachments/assets/09e72ba6-7ae2-467f-b379-dde1b9455ae2)

Older OS settings: 
![image](https://github.com/user-attachments/assets/895e540f-dc46-4d18-9f7a-7aa0516cebbc)

