### PR TITLE
fix: Prevent sending message on IME confirmation with Enter key

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -906,6 +906,15 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		editorOptions.contributions?.push(...EditorExtensionsRegistry.getSomeEditorContributions([ContentHoverController.ID, GlyphHoverController.ID, CopyPasteController.ID, LinkDetector.ID]));
 		this._inputEditor = this._register(scopedInstantiationService.createInstance(CodeEditorWidget, this._inputEditorElement, options, editorOptions));
 
+		this._register(this._inputEditor.onKeyDown(e => {
+			if (e.keyCode === KeyCode.Enter && !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
+				if (e.browserEvent.isComposing) {
+					e.preventDefault();
+					e.stopPropagation();
+				}
+			}
+		}));
+
 		SuggestController.get(this._inputEditor)?.forceRenderingAbove();
 		options.overflowWidgetsDomNode?.classList.add('hideSuggestTextIcons');
 		this._inputEditorElement.classList.add('hideSuggestTextIcons');


### PR DESCRIPTION
When typing in languages that require IME composition (e.g., Japanese) in a chat interface with an LLM, Enter needs to be pressed twice. However, the message is currently sent on the first Enter key press during composition.

To fix this, I prevented the default action when e.browserEvent.isComposing is true, ensuring that the message is not sent while IME composition is still in progress.