### PR TITLE
Fix: Add null checks to themeMainService to prevent crashes

### DIFF
--- a/src/vs/platform/theme/electron-main/themeMainService.ts
+++ b/src/vs/platform/theme/electron-main/themeMainService.ts
@@ -237,9 +237,13 @@ export class ThemeMainService extends Disposable implements IThemeMainService {
 		// Apply workspace specific overrides
 		let auxiliarySideBarWidthOverride: number | undefined;
 		if (workspace) {
-			const [auxiliarySideBarWidth, workspaceIds] = this.getWindowSplashOverride().layoutInfo.auxiliarySideBarWidth;
-			if (workspaceIds.includes(workspace.id)) {
-				auxiliarySideBarWidthOverride = auxiliarySideBarWidth;
+			const override = this.getWindowSplashOverride();
+			const auxiliarySideBarWidthData = override?.layoutInfo?.auxiliarySideBarWidth;
+			if (Array.isArray(auxiliarySideBarWidthData) && auxiliarySideBarWidthData.length >= 2) {
+				const [auxiliarySideBarWidth, workspaceIds] = auxiliarySideBarWidthData;
+				if (Array.isArray(workspaceIds) && workspaceIds.includes(workspace.id)) {
+					auxiliarySideBarWidthOverride = auxiliarySideBarWidth;
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
Fixed a potential crash in themeMainService when workspace splash override data is missing or malformed.

## Changes
- Added null/undefined checks before accessing layoutInfo.auxiliarySideBarWidth
- Added Array.isArray checks to ensure proper data structure before destructuring
- Prevents TypeError when workspace splash override data is missing

## Problem
The code was assuming that getWindowSplashOverride().layoutInfo.auxiliarySideBarWidth would always be a valid array with 2 elements, causing crashes when the data was undefined or malformed.