### PR TITLE
Improve: Better error messages for Fast Apply

### DIFF
--- a/src/vs/workbench/contrib/void/browser/editCodeService.ts
+++ b/src/vs/workbench/contrib/void/browser/editCodeService.ts
@@ -1615,7 +1615,7 @@ class EditCodeService extends Disposable implements IEditCodeService {
 
 	private _instantlyApplySRBlocks(uri: URI, blocksStr: string) {
 		const blocks = extractSearchReplaceBlocks(blocksStr)
-		if (blocks.length === 0) throw new Error(`No Search/Replace blocks were received!`)
+		if (blocks.length === 0) throw new Error(`No Search/Replace blocks were received! The LLM response did not contain the expected format:\n<<<<<<< ORIGINAL\n[original code]\n=======\n[new code]\n>>>>>>> UPDATED`)
 
 		const { model } = this._voidModelService.getModel(uri)
 		if (!model) throw new Error(`Error applying Search/Replace blocks: File does not exist.`)
@@ -1968,7 +1968,11 @@ class EditCodeService extends Disposable implements IEditCodeService {
 
 						const blocks = extractSearchReplaceBlocks(fullText)
 						if (blocks.length === 0) {
-							this._notificationService.info(`Void: We ran Fast Apply, but the LLM didn't output any changes.`)
+							this._notificationService.info(`Void: We ran Fast Apply, but the LLM didn't output any changes. The model may not have returned the expected SEARCH/REPLACE format.`)
+							this._writeURIText(uri, originalFileCode, 'wholeFileRange', { shouldRealignDiffAreas: true })
+							onDone()
+							resMessageDonePromise()
+							return
 						}
 						this._writeURIText(uri, originalFileCode, 'wholeFileRange', { shouldRealignDiffAreas: true })
 


### PR DESCRIPTION
## Summary
Improved error messaging when Fast Apply fails to find any Search/Replace blocks in the LLM response.

## Changes
- Added expected format example to error message when no Search/Replace blocks are found
- Improved notification message to better explain why no changes were applied
- Added proper cleanup (restore original file, call onDone) when Fast Apply returns no changes

## Why
When Fast Apply fails, users were getting a vague error message. Now they see the expected format, which helps them understand and potentially debug the issue.