### PR TITLE
Fix Llama model fallback logic in modelCapabilities.ts

### DIFF
--- a/src/vs/workbench/contrib/void/common/modelCapabilities.ts
+++ b/src/vs/workbench/contrib/void/common/modelCapabilities.ts
@@ -426,12 +426,12 @@ const extensiveModelOptionsFallback: VoidStaticProviderInfo['modelOptionsFallbac
 	if (lower.includes('deepseek') && lower.includes('v2')) return toFallback(openSourceModelOptions_assumingOAICompat, 'deepseekCoderV2')
 	if (lower.includes('deepseek')) return toFallback(openSourceModelOptions_assumingOAICompat, 'deepseekCoderV3')
 
-	if (lower.includes('llama3')) return toFallback(openSourceModelOptions_assumingOAICompat, 'llama3')
 	if (lower.includes('llama3.1')) return toFallback(openSourceModelOptions_assumingOAICompat, 'llama3.1')
 	if (lower.includes('llama3.2')) return toFallback(openSourceModelOptions_assumingOAICompat, 'llama3.2')
 	if (lower.includes('llama3.3')) return toFallback(openSourceModelOptions_assumingOAICompat, 'llama3.3')
+	if (lower.includes('llama3')) return toFallback(openSourceModelOptions_assumingOAICompat, 'llama3')
 	if (lower.includes('llama') || lower.includes('scout')) return toFallback(openSourceModelOptions_assumingOAICompat, 'llama4-scout')
-	if (lower.includes('llama') || lower.includes('maverick')) return toFallback(openSourceModelOptions_assumingOAICompat, 'llama4-scout')
+	if (lower.includes('llama') || lower.includes('maverick')) return toFallback(openSourceModelOptions_assumingOAICompat, 'llama4-maverick')
 	if (lower.includes('llama')) return toFallback(openSourceModelOptions_assumingOAICompat, 'llama4-scout')
 
 	if (lower.includes('qwen') && lower.includes('2.5') && lower.includes('coder')) return toFallback(openSourceModelOptions_assumingOAICompat, 'qwen2.5coder')


### PR DESCRIPTION
This pull request updates the fallback logic for Llama models in `modelCapabilities.ts`.

### Llama 3

The current fallback logic for Llama3 behaves as follows (in order):

1. if `modelName` includes `llama3` → use `llama3`
2. else if `modelName` includes `llama3.1` → use `llama3.1`
3. else if `modelName` includes `llama3.2` → use `llama3.2`
4. else if `modelName` includes `llama3.3` → use `llama3.3`

With this order, any `modelName` that includes `llama3.1`, `llama3.2` or `llama3.3` matches clause (1), and is captured by the generic `llama3` before it can fall back to the more specific `llama3.1`, `llama3.2`, or `llama3.3` variants as intended.

This PR fixes the issue by moving clause (1) to the end, so that the specific `llama3.1` / `llama3.2` / `llama3.3` take precedence over the generic `llama3` match.

### Llama 4

Currently a `modelName` matching `llama4-maverick` incorrectly falls back to `llama4-scout`. This PR also fixes this issue. 