### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/src/vs/workbench/contrib/void/common/modelCapabilities.ts
+++ b/src/vs/workbench/contrib/void/common/modelCapabilities.ts
@@ -157,6 +157,8 @@ export const defaultModelsOfProvider = {
 	awsBedrock: [],
 	liteLLM: [],
 	minimax: [ // https://platform.minimax.io/docs/api-reference/text-openai-api
+		'MiniMax-M2.7',
+		'MiniMax-M2.7-highspeed',
 		'MiniMax-M2.5',
 		'MiniMax-M2.5-highspeed',
 	],
@@ -964,6 +966,26 @@ const deepseekSettings: VoidStaticProviderInfo = {
 
 // ---------------- MINIMAX ----------------
 const minimaxModelOptions = { // https://platform.minimax.io/docs/api-reference/text-openai-api
+	'MiniMax-M2.7': {
+		contextWindow: 204_800,
+		reservedOutputTokenSpace: 8_192,
+		cost: { input: 0.30, output: 1.20 },
+		downloadable: false,
+		supportsFIM: false,
+		supportsSystemMessage: 'system-role' as const,
+		specialToolFormat: 'openai-style' as const,
+		reasoningCapabilities: false as const,
+	},
+	'MiniMax-M2.7-highspeed': {
+		contextWindow: 204_800,
+		reservedOutputTokenSpace: 8_192,
+		cost: { input: 0.60, output: 2.40 },
+		downloadable: false,
+		supportsFIM: false,
+		supportsSystemMessage: 'system-role' as const,
+		specialToolFormat: 'openai-style' as const,
+		reasoningCapabilities: false as const,
+	},
 	'MiniMax-M2.5': {
 		contextWindow: 204_800,
 		reservedOutputTokenSpace: 8_192,
@@ -990,7 +1012,7 @@ const minimaxSettings: VoidStaticProviderInfo = {
 	modelOptions: minimaxModelOptions,
 	modelOptionsFallback: (modelName) => {
 		const lower = modelName.toLowerCase()
-		if (lower.includes('minimax')) return { modelName: 'MiniMax-M2.5', recognizedModelName: 'MiniMax-M2.5', ...minimaxModelOptions['MiniMax-M2.5'] }
+		if (lower.includes('minimax')) return { modelName: 'MiniMax-M2.7', recognizedModelName: 'MiniMax-M2.7', ...minimaxModelOptions['MiniMax-M2.7'] }
 		return null
 	},
 }

--- a/src/vs/workbench/contrib/void/common/modelCapabilities.ts
+++ b/src/vs/workbench/contrib/void/common/modelCapabilities.ts
@@ -65,6 +65,9 @@ export const defaultProviderSettings = {
 		region: 'us-east-1', // add region setting
 		endpoint: '', // optionally allow overriding default
 	},
+	minimax: {
+		apiKey: '',
+	},
 
 } as const
 
@@ -153,6 +156,10 @@ export const defaultModelsOfProvider = {
 	microsoftAzure: [],
 	awsBedrock: [],
 	liteLLM: [],
+	minimax: [ // https://platform.minimax.io/docs/api-reference/text-openai-api
+		'MiniMax-M2.5',
+		'MiniMax-M2.5-highspeed',
+	],
 
 
 } as const satisfies Record<ProviderName, string[]>
@@ -955,6 +962,41 @@ const deepseekSettings: VoidStaticProviderInfo = {
 
 
 
+// ---------------- MINIMAX ----------------
+const minimaxModelOptions = { // https://platform.minimax.io/docs/api-reference/text-openai-api
+	'MiniMax-M2.5': {
+		contextWindow: 204_800,
+		reservedOutputTokenSpace: 8_192,
+		cost: { input: 0.30, output: 1.20 },
+		downloadable: false,
+		supportsFIM: false,
+		supportsSystemMessage: 'system-role' as const,
+		specialToolFormat: 'openai-style' as const,
+		reasoningCapabilities: false as const,
+	},
+	'MiniMax-M2.5-highspeed': {
+		contextWindow: 204_800,
+		reservedOutputTokenSpace: 8_192,
+		cost: { input: 0.60, output: 2.40 },
+		downloadable: false,
+		supportsFIM: false,
+		supportsSystemMessage: 'system-role' as const,
+		specialToolFormat: 'openai-style' as const,
+		reasoningCapabilities: false as const,
+	},
+} as const satisfies { [s: string]: VoidStaticModelInfo }
+
+const minimaxSettings: VoidStaticProviderInfo = {
+	modelOptions: minimaxModelOptions,
+	modelOptionsFallback: (modelName) => {
+		const lower = modelName.toLowerCase()
+		if (lower.includes('minimax')) return { modelName: 'MiniMax-M2.5', recognizedModelName: 'MiniMax-M2.5', ...minimaxModelOptions['MiniMax-M2.5'] }
+		return null
+	},
+}
+
+
+
 // ---------------- MISTRAL ----------------
 
 const mistralModelOptions = { // https://mistral.ai/products/la-plateforme#pricing https://docs.mistral.ai/getting-started/models/models_overview/#premier-models
@@ -1474,6 +1516,7 @@ const modelSettingsOfProvider: { [providerName in ProviderName]: VoidStaticProvi
 	googleVertex: googleVertexSettings,
 	microsoftAzure: microsoftAzureSettings,
 	awsBedrock: awsBedrockSettings,
+	minimax: minimaxSettings,
 } as const
 
 

--- a/src/vs/workbench/contrib/void/common/modelCapabilities.ts
+++ b/src/vs/workbench/contrib/void/common/modelCapabilities.ts
@@ -157,10 +157,9 @@ export const defaultModelsOfProvider = {
 	awsBedrock: [],
 	liteLLM: [],
 	minimax: [ // https://platform.minimax.io/docs/api-reference/text-openai-api
+		'MiniMax-M3',
 		'MiniMax-M2.7',
 		'MiniMax-M2.7-highspeed',
-		'MiniMax-M2.5',
-		'MiniMax-M2.5-highspeed',
 	],
 
 
@@ -966,6 +965,16 @@ const deepseekSettings: VoidStaticProviderInfo = {
 
 // ---------------- MINIMAX ----------------
 const minimaxModelOptions = { // https://platform.minimax.io/docs/api-reference/text-openai-api
+	'MiniMax-M3': {
+		contextWindow: 512_000,
+		reservedOutputTokenSpace: 16_384,
+		cost: { input: 0.60, output: 2.40, cache_read: 0.12 },
+		downloadable: false,
+		supportsFIM: false,
+		supportsSystemMessage: 'system-role' as const,
+		specialToolFormat: 'openai-style' as const,
+		reasoningCapabilities: false as const,
+	},
 	'MiniMax-M2.7': {
 		contextWindow: 204_800,
 		reservedOutputTokenSpace: 8_192,
@@ -986,33 +995,13 @@ const minimaxModelOptions = { // https://platform.minimax.io/docs/api-reference/
 		specialToolFormat: 'openai-style' as const,
 		reasoningCapabilities: false as const,
 	},
-	'MiniMax-M2.5': {
-		contextWindow: 204_800,
-		reservedOutputTokenSpace: 8_192,
-		cost: { input: 0.30, output: 1.20 },
-		downloadable: false,
-		supportsFIM: false,
-		supportsSystemMessage: 'system-role' as const,
-		specialToolFormat: 'openai-style' as const,
-		reasoningCapabilities: false as const,
-	},
-	'MiniMax-M2.5-highspeed': {
-		contextWindow: 204_800,
-		reservedOutputTokenSpace: 8_192,
-		cost: { input: 0.60, output: 2.40 },
-		downloadable: false,
-		supportsFIM: false,
-		supportsSystemMessage: 'system-role' as const,
-		specialToolFormat: 'openai-style' as const,
-		reasoningCapabilities: false as const,
-	},
 } as const satisfies { [s: string]: VoidStaticModelInfo }
 
 const minimaxSettings: VoidStaticProviderInfo = {
 	modelOptions: minimaxModelOptions,
 	modelOptionsFallback: (modelName) => {
 		const lower = modelName.toLowerCase()
-		if (lower.includes('minimax')) return { modelName: 'MiniMax-M2.7', recognizedModelName: 'MiniMax-M2.7', ...minimaxModelOptions['MiniMax-M2.7'] }
+		if (lower.includes('minimax')) return { modelName: 'MiniMax-M3', recognizedModelName: 'MiniMax-M3', ...minimaxModelOptions['MiniMax-M3'] }
 		return null
 	},
 }

--- a/src/vs/workbench/contrib/void/common/voidSettingsTypes.ts
+++ b/src/vs/workbench/contrib/void/common/voidSettingsTypes.ts
@@ -106,6 +106,9 @@ export const displayInfoOfProviderName = (providerName: ProviderName): DisplayIn
 	else if (providerName === 'awsBedrock') {
 		return { title: 'AWS Bedrock', }
 	}
+	else if (providerName === 'minimax') {
+		return { title: 'MiniMax', }
+	}
 
 	throw new Error(`descOfProviderName: Unknown provider name: "${providerName}"`)
 }
@@ -128,6 +131,7 @@ export const subTextMdOfProviderName = (providerName: ProviderName): string => {
 	if (providerName === 'vLLM') return 'Read more about custom [Endpoints here](https://docs.vllm.ai/en/latest/getting_started/quickstart.html#openai-compatible-server).'
 	if (providerName === 'lmStudio') return 'Read more about custom [Endpoints here](https://lmstudio.ai/docs/app/api/endpoints/openai).'
 	if (providerName === 'liteLLM') return 'Read more about endpoints [here](https://docs.litellm.ai/docs/providers/openai_compatible).'
+	if (providerName === 'minimax') return 'Get your [API Key here](https://platform.minimax.io). Read more about [models here](https://platform.minimax.io/docs/api-reference/text-openai-api).'
 
 	throw new Error(`subTextMdOfProviderName: Unknown provider name: "${providerName}"`)
 }
@@ -156,6 +160,7 @@ export const displayInfoOfSettingName = (providerName: ProviderName, settingName
 												providerName === 'googleVertex' ? 'AIzaSy...' :
 													providerName === 'microsoftAzure' ? 'key-...' :
 														providerName === 'awsBedrock' ? 'key-...' :
+												providerName === 'minimax' ? 'eyJhbGci...' :
 															'',
 
 			isPasswordField: true,
@@ -350,6 +355,12 @@ export const defaultSettingsOfProvider: SettingsOfProvider = {
 		...defaultCustomSettings,
 		...defaultProviderSettings.awsBedrock,
 		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.awsBedrock),
+		_didFillInProviderSettings: undefined,
+	},
+	minimax: {
+		...defaultCustomSettings,
+		...defaultProviderSettings.minimax,
+		...modelInfoOfDefaultModelNames(defaultModelsOfProvider.minimax),
 		_didFillInProviderSettings: undefined,
 	},
 }

--- a/src/vs/workbench/contrib/void/electron-main/llmMessage/sendLLMMessage.impl.ts
+++ b/src/vs/workbench/contrib/void/electron-main/llmMessage/sendLLMMessage.impl.ts
@@ -167,6 +167,10 @@ const newOpenAICompatibleSDK = async ({ settingsOfProvider, providerName, includ
 		const thisConfig = settingsOfProvider[providerName]
 		return new OpenAI({ baseURL: 'https://api.mistral.ai/v1', apiKey: thisConfig.apiKey, ...commonPayloadOpts })
 	}
+	else if (providerName === 'minimax') {
+		const thisConfig = settingsOfProvider[providerName]
+		return new OpenAI({ baseURL: 'https://api.minimax.io/v1', apiKey: thisConfig.apiKey, ...commonPayloadOpts })
+	}
 
 	else throw new Error(`Void providerName was invalid: ${providerName}.`)
 }
@@ -933,6 +937,11 @@ export const sendLLMMessageToProviderImplementation = {
 		list: null,
 	},
 	awsBedrock: {
+		sendChat: (params) => _sendOpenAICompatibleChat(params),
+		sendFIM: null,
+		list: null,
+	},
+	minimax: {
 		sendChat: (params) => _sendOpenAICompatibleChat(params),
 		sendFIM: null,
 		list: null,


### PR DESCRIPTION
## Summary
Upgrade the MiniMax provider's default model to **MiniMax-M3**, the latest flagship release.

## Changes
- Add `MiniMax-M3` to the model selection list and set it as the default
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Remove older models (`MiniMax-M2.5` / `MiniMax-M2.5-highspeed`)
- Update the model fallback handler to route unknown MiniMax models to M3

## Models

| Model | Context | Reserved Output | Input | Output | Cache Read |
|-------|---------|-----------------|-------|--------|-----------|
| `MiniMax-M3` (default) | 512K | 16K | $0.60/M | $2.40/M | $0.12/M |
| `MiniMax-M2.7` | 204K | 8K | $0.30/M | $1.20/M | — |
| `MiniMax-M2.7-highspeed` | 204K | 8K | $0.60/M | $2.40/M | — |

## Why
`MiniMax-M3` is the latest MiniMax model with a 512K context window, up to 128K max output, and image input support. Older M2.5 variants are superseded and removed; M2.7 family is retained for users who need the previous behavior.

## Testing
- Model list updated and statically validated against `VoidStaticModelInfo` (via `satisfies`)
- Fallback handler routes unknown MiniMax model names to `MiniMax-M3`
- OpenAI-compatible endpoint unchanged: `https://api.minimax.io/v1`