### PR TITLE
fix: add position:relative to .interactive-session for dnd overlay

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -6,6 +6,7 @@
 .interactive-session {
 	max-width: 850px;
 	margin: auto;
+	position: relative;
 }
 
 .interactive-list > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row > .monaco-tl-row > .monaco-tl-twistie {


### PR DESCRIPTION
Fixes #925

## Problem

Dragging files from the Explorer to the Chat panel does not show the blue drop overlay. The `.chat-dnd-overlay` element uses `position: absolute` to cover the chat session container, but its parent `.interactive-session` was missing `position: relative`. Without a positioning context on the parent, the absolutely-positioned overlay is anchored to a wrong ancestor element (e.g., the viewport), causing it to render off-screen with no visible feedback during drag operations.

## Solution

Add `position: relative` to `.interactive-session` in `chat.css`. This provides the correct positioning context so `.chat-dnd-overlay` is sized and positioned relative to the chat panel rather than a distant ancestor.

```css
/* Before */
.interactive-session {
    max-width: 850px;
    margin: auto;
}

/* After */
.interactive-session {
    max-width: 850px;
    margin: auto;
    position: relative;
}
```

## Testing

- Drag a file from the Explorer panel into the Chat panel — the blue overlay now appears correctly
- Existing drag-and-drop logic in `chatDragAndDrop.ts` is unchanged; this is a one-line CSS-only fix
- No regressions to layout: `position: relative` without explicit `top/left/width/height` has no visual side effects on the container itself