### PR TITLE
fix: enable native OpenAI-style tool calling for local model providers

### DIFF
--- a/src/vs/workbench/contrib/void/common/modelCapabilities.ts
+++ b/src/vs/workbench/contrib/void/common/modelCapabilities.ts
@@ -258,36 +258,42 @@ const openSourceModelOptions_assumingOAICompat = {
 	'deepseekR1': {
 		supportsFIM: false,
 		supportsSystemMessage: false,
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: { supportsReasoning: true, canTurnOffReasoning: false, canIOReasoning: true, openSourceThinkTags: ['<think>', '</think>'] },
 		contextWindow: 32_000, reservedOutputTokenSpace: 4_096,
 	},
 	'deepseekCoderV3': {
 		supportsFIM: false,
 		supportsSystemMessage: false, // unstable
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 		contextWindow: 32_000, reservedOutputTokenSpace: 4_096,
 	},
 	'deepseekCoderV2': {
 		supportsFIM: false,
 		supportsSystemMessage: false, // unstable
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 		contextWindow: 32_000, reservedOutputTokenSpace: 4_096,
 	},
 	'codestral': {
 		supportsFIM: true,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 		contextWindow: 32_000, reservedOutputTokenSpace: 4_096,
 	},
 	'devstral': {
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 		contextWindow: 131_000, reservedOutputTokenSpace: 8_192,
 	},
 	'openhands-lm-32b': { // https://www.all-hands.dev/blog/introducing-openhands-lm-32b----a-strong-open-coding-agent-model
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false, // built on qwen 2.5 32B instruct
 		contextWindow: 128_000, reservedOutputTokenSpace: 4_096
 	},
@@ -296,6 +302,7 @@ const openSourceModelOptions_assumingOAICompat = {
 	'phi4': {
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: { supportsReasoning: true, canTurnOffReasoning: true, canIOReasoning: true, openSourceThinkTags: ['<think>', '</think>'] },
 		contextWindow: 16_000, reservedOutputTokenSpace: 4_096,
 	},
@@ -303,6 +310,7 @@ const openSourceModelOptions_assumingOAICompat = {
 	'gemma': { // https://news.ycombinator.com/item?id=43451406
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 		contextWindow: 32_000, reservedOutputTokenSpace: 4_096,
 	},
@@ -310,12 +318,14 @@ const openSourceModelOptions_assumingOAICompat = {
 	'llama4-scout': {
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 		contextWindow: 10_000_000, reservedOutputTokenSpace: 4_096,
 	},
 	'llama4-maverick': {
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 		contextWindow: 10_000_000, reservedOutputTokenSpace: 4_096,
 	},
@@ -324,24 +334,28 @@ const openSourceModelOptions_assumingOAICompat = {
 	'llama3': {
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 		contextWindow: 32_000, reservedOutputTokenSpace: 4_096,
 	},
 	'llama3.1': {
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 		contextWindow: 32_000, reservedOutputTokenSpace: 4_096,
 	},
 	'llama3.2': {
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 		contextWindow: 32_000, reservedOutputTokenSpace: 4_096,
 	},
 	'llama3.3': {
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 		contextWindow: 32_000, reservedOutputTokenSpace: 4_096,
 	},
@@ -349,18 +363,21 @@ const openSourceModelOptions_assumingOAICompat = {
 	'qwen2.5coder': {
 		supportsFIM: true,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 		contextWindow: 32_000, reservedOutputTokenSpace: 4_096,
 	},
 	'qwq': {
 		supportsFIM: false, // no FIM, yes reasoning
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: { supportsReasoning: true, canTurnOffReasoning: false, canIOReasoning: true, openSourceThinkTags: ['<think>', '</think>'] },
 		contextWindow: 128_000, reservedOutputTokenSpace: 8_192,
 	},
 	'qwen3': {
 		supportsFIM: false, // replaces QwQ
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: { supportsReasoning: true, canTurnOffReasoning: true, canIOReasoning: true, openSourceThinkTags: ['<think>', '</think>'] },
 		contextWindow: 32_768, reservedOutputTokenSpace: 8_192,
 	},
@@ -1143,6 +1160,7 @@ const ollamaModelOptions = {
 		downloadable: { sizeGb: 1.9 },
 		supportsFIM: true,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 	},
 	'qwen2.5-coder:3b': {
@@ -1152,6 +1170,7 @@ const ollamaModelOptions = {
 		downloadable: { sizeGb: 1.9 },
 		supportsFIM: true,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 	},
 	'qwen2.5-coder:1.5b': {
@@ -1161,6 +1180,7 @@ const ollamaModelOptions = {
 		downloadable: { sizeGb: .986 },
 		supportsFIM: true,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 	},
 	'llama3.1': {
@@ -1170,6 +1190,7 @@ const ollamaModelOptions = {
 		downloadable: { sizeGb: 4.9 },
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 	},
 	'qwen2.5-coder': {
@@ -1179,6 +1200,7 @@ const ollamaModelOptions = {
 		downloadable: { sizeGb: 4.7 },
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 	},
 	'qwq': {
@@ -1188,6 +1210,7 @@ const ollamaModelOptions = {
 		downloadable: { sizeGb: 20 },
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: { supportsReasoning: true, canIOReasoning: false, canTurnOffReasoning: false, openSourceThinkTags: ['<think>', '</think>'] },
 	},
 	'deepseek-r1': {
@@ -1197,6 +1220,7 @@ const ollamaModelOptions = {
 		downloadable: { sizeGb: 4.7 },
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: { supportsReasoning: true, canIOReasoning: false, canTurnOffReasoning: false, openSourceThinkTags: ['<think>', '</think>'] },
 	},
 	'devstral:latest': {
@@ -1206,6 +1230,7 @@ const ollamaModelOptions = {
 		downloadable: { sizeGb: 14 },
 		supportsFIM: false,
 		supportsSystemMessage: 'system-role',
+		specialToolFormat: 'openai-style',
 		reasoningCapabilities: false,
 	},
 


### PR DESCRIPTION
Fixes #857

## Problem

Local model providers (Ollama, vLLM, LM Studio, liteLLM, openAICompatible) all expose an OpenAI-compatible API that supports native function/tool calling. However, models served via these providers were missing `specialToolFormat: 'openai-style'` in their capability definitions.

Without this flag, Void falls back to XML-based tool prompting (embedding tool definitions in the system prompt and parsing XML tags from the model's text output). This approach is unreliable for modern local models that expect to receive tools via the standard `tools` parameter and return `tool_calls` in structured JSON.

As a result, users see errors like `"No Search/Replace blocks were received!"` because:
1. The `tools` parameter is never sent in API requests to local providers
2. The model has no idea it should produce tool calls
3. The XML parser finds nothing to extract

This is consistently reported across multiple models: qwen3-coder, qwen2.5-coder, llama3.x, devstral, gemma, etc. via Ollama, vLLM, LM Studio, and liteLLM.

## Solution

Add `specialToolFormat: 'openai-style'` to all chat/agent-capable models in:
- `openSourceModelOptions_assumingOAICompat` (used as fallback for unrecognized model names)
- `ollamaModelOptions` (Ollama-specific recognized models)

This enables:
1. The `tools` parameter to be sent in API requests to local providers
2. Native `tool_calls` responses to be parsed correctly (already implemented in the streaming handler)
3. The XML tool-prompting fallback to be skipped (it's not needed when native tool calling works)

Users who need to disable native tool calling for a specific model can override via the `specialToolFormat` field in their model's advanced settings JSON.

## Testing

The fix is targeted at model capability definitions only and affects no runtime logic. The existing streaming handler already processes `tool_calls` from OpenAI-compatible responses correctly — the missing piece was sending the `tools` parameter.